### PR TITLE
Fix Do no work: cargo run start -m "all=2" (fix #12)

### DIFF
--- a/src/procfile.rs
+++ b/src/procfile.rs
@@ -47,7 +47,19 @@ impl Procfile {
     }
 
     pub fn set_concurrency(&self, formation: &str) {
+        // e.g.) all=1
         if formation == DEFAULT_FORMATION {
+            return ();
+        }
+
+        // e.g.) all=2
+        let data: Vec<&str> = formation.split("=").collect();
+        let name = data[0];
+        if name == "all" {
+            let concurrency = data[1].parse::<usize>().unwrap();
+            for (_, pe) in self.data.iter() {
+                pe.concurrency.set(concurrency);
+            }
             return ();
         }
 
@@ -195,6 +207,18 @@ mod tests {
         pf.set_concurrency(formation);
         assert_eq!(pf.data.get("app").unwrap().concurrency.get(), 2);
         assert_eq!(pf.data.get("web").unwrap().concurrency.get(), 3);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_set_concurrency_all() -> anyhow::Result<()> {
+        let formation = "all=10";
+        let pf = create_procfile();
+
+        pf.set_concurrency(formation);
+        assert_eq!(pf.data.get("app").unwrap().concurrency.get(), 10);
+        assert_eq!(pf.data.get("web").unwrap().concurrency.get(), 10);
 
         Ok(())
     }


### PR DESCRIPTION
### Summary

Resolve #12

### Work

when all=10

```bash
$ cargo run start -m "all=10"
   Compiling ultraman v0.1.0 (/Users/yukihirop/RustProjects/ultraman)
warning: use of deprecated function `dotenv::from_path_iter`: please use `from_path` in conjunction with `var` instead
  --> src/env.rs:10:25
   |
10 |     if let Some(iter) = dotenv::from_path_iter(filepath.as_path()).ok() {
   |                         ^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: 1 warning emitted

    Finished dev [unoptimized + debuginfo] target(s) in 3.86s
     Running `target/debug/ultraman start -m all=10`
12:37:14 system    | exit_1.5  start at pid: 11357
12:37:14 system    | exit_0.1  start at pid: 11358
12:37:14 system    | exit_1.9  start at pid: 11359
12:37:14 system    | loop.1    start at pid: 11360
12:37:14 system    | exit_0.8  start at pid: 11361
12:37:14 system    | loop.2    start at pid: 11362
12:37:14 system    | exit_0.4  start at pid: 11363
12:37:14 system    | exit_0.6  start at pid: 11364
12:37:14 system    | exit_0.2  start at pid: 11365
12:37:14 system    | loop.8    start at pid: 11366
12:37:14 system    | exit_0.10 start at pid: 11367
12:37:14 system    | exit_0.9  start at pid: 11368
12:37:14 system    | exit_0.5  start at pid: 11383
12:37:14 system    | exit_1.10 start at pid: 11378
12:37:14 system    | exit_1.3  start at pid: 11379
12:37:14 system    | loop.5    start at pid: 11380
12:37:14 system    | loop.6    start at pid: 11381
12:37:14 system    | loop.7    start at pid: 11382
12:37:14 system    | exit_1.4  start at pid: 11373
12:37:14 system    | exit_1.8  start at pid: 11384
12:37:14 system    | exit_1.7  start at pid: 11385
12:37:14 system    | loop.3    start at pid: 11386
12:37:14 system    | exit_1.6  start at pid: 11387
12:37:14 system    | exit_1.2  start at pid: 11394
12:37:14 system    | loop.9    start at pid: 11399
12:37:14 system    | exit_1.1  start at pid: 11402
12:37:14 system    | exit_0.7  start at pid: 11404
12:37:14 system    | loop.10   start at pid: 11405
12:37:14 system    | loop.4    start at pid: 11407
12:37:14 system    | exit_0.3  start at pid: 11409
12:37:15 loop.2    | Hello World
12:37:15 loop.1    | Hello World
12:37:15 loop.8    | Hello World
12:37:15 loop.7    | Hello World
12:37:15 loop.5    | Hello World
12:37:15 loop.6    | Hello World
12:37:15 loop.3    | Hello World
12:37:15 loop.9    | Hello World
12:37:15 loop.10   | Hello World
12:37:15 loop.4    | Hello World
12:37:16 exit_1.9  | failed
12:37:16 exit_1.5  | failed
12:37:16 exit_1.5  | exited with code 1
12:37:16 system    | sending SIGTERM for exit_0.1  at pid 11358
12:37:16 system    | sending SIGTERM for exit_1.9  at pid 11359
12:37:16 system    | sending SIGTERM for loop.1    at pid 11360
12:37:16 system    | sending SIGTERM for exit_0.8  at pid 11361
12:37:16 system    | sending SIGTERM for loop.2    at pid 11362
12:37:16 system    | sending SIGTERM for exit_0.4  at pid 11363
12:37:16 system    | sending SIGTERM for exit_0.6  at pid 11364
12:37:16 system    | sending SIGTERM for exit_0.2  at pid 11365
12:37:16 system    | sending SIGTERM for exit_0.10 at pid 11367
12:37:16 system    | sending SIGTERM for loop.8    at pid 11366
12:37:16 system    | sending SIGTERM for exit_0.9  at pid 11368
12:37:16 system    | sending SIGTERM for exit_0.5  at pid 11383
12:37:16 system    | sending SIGTERM for exit_1.10 at pid 11378
12:37:16 system    | sending SIGTERM for exit_1.3  at pid 11379
12:37:16 system    | sending SIGTERM for loop.5    at pid 11380
12:37:16 system    | sending SIGTERM for loop.6    at pid 11381
12:37:16 system    | sending SIGTERM for loop.7    at pid 11382
12:37:16 system    | sending SIGTERM for exit_1.4  at pid 11373
12:37:16 system    | sending SIGTERM for exit_1.8  at pid 11384
12:37:16 system    | sending SIGTERM for exit_1.7  at pid 11385
12:37:16 system    | sending SIGTERM for loop.3    at pid 11386
12:37:16 system    | sending SIGTERM for exit_1.6  at pid 11387
12:37:16 system    | sending SIGTERM for exit_1.2  at pid 11394
12:37:16 system    | sending SIGTERM for loop.9    at pid 11399
12:37:16 system    | sending SIGTERM for exit_1.1  at pid 11402
12:37:16 system    | sending SIGTERM for exit_0.7  at pid 11404
12:37:16 system    | sending SIGTERM for loop.10   at pid 11405
12:37:16 system    | sending SIGTERM for loop.4    at pid 11407
12:37:16 system    | sending SIGTERM for exit_0.3  at pid 11409
12:37:16 exit_0.5  | terminated by SIGTERM
12:37:16 loop.7    | terminated by SIGTERM
12:37:16 exit_1.7  | terminated by SIGTERM
12:37:16 exit_1.6  | terminated by SIGTERM
12:37:16 loop.3    | terminated by SIGTERM
12:37:16 exit_1.8  | terminated by SIGTERM
12:37:16 loop.9    | terminated by SIGTERM
12:37:16 exit_1.2  | terminated by SIGTERM
12:37:16 exit_0.7  | terminated by SIGTERM
12:37:16 loop.10   | terminated by SIGTERM
12:37:16 exit_0.3  | terminated by SIGTERM
12:37:16 loop.4    | terminated by SIGTERM
12:37:16 exit_1.1  | terminated by SIGTERM
12:37:16 loop.6    | terminated by SIGTERM
12:37:16 loop.5    | terminated by SIGTERM
12:37:16 exit_1.3  | terminated by SIGTERM
12:37:16 exit_1.10 | terminated by SIGTERM
12:37:16 exit_1.4  | terminated by SIGTERM
12:37:16 exit_0.9  | terminated by SIGTERM
12:37:16 exit_0.10 | terminated by SIGTERM
12:37:16 loop.8    | terminated by SIGTERM
12:37:16 exit_0.2  | terminated by SIGTERM
12:37:16 exit_0.6  | terminated by SIGTERM
12:37:16 exit_0.4  | terminated by SIGTERM
12:37:16 loop.2    | terminated by SIGTERM
12:37:16 exit_0.8  | terminated by SIGTERM
12:37:16 loop.1    | terminated by SIGTERM
12:37:16 exit_1.9  | exited with code 1
12:37:16 system    | sending SIGTERM for exit_0.1  at pid 11358
12:37:16 exit_0.1  | terminated by SIGTERM
```

### Test

```bash
$ cargo test
warning: use of deprecated function `dotenv::from_path_iter`: please use `from_path` in conjunction with `var` instead
  --> src/env.rs:10:25
   |
10 |     if let Some(iter) = dotenv::from_path_iter(filepath.as_path()).ok() {
   |                         ^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: 1 warning emitted

    Finished test [unoptimized + debuginfo] target(s) in 0.23s
     Running target/debug/deps/ultraman-30dae6b0a9086ede

running 17 tests
test procfile::tests::test_find_by ... ok
test procfile::tests::test_padding ... ok
test log::tests::test_output_when_not_coloring ... ok
test procfile::tests::test_process_len ... ok
test procfile::tests::test_set_concurrency ... ok
test procfile::tests::test_set_concurrency_all ... ok
test env::tests::test_read_env ... ok
test log::tests::test_error ... ok
test procfile::tests::test_set_concurrency_when_panic ... ok
test log::tests::test_output_when_coloring ... ok
test procfile::tests::test_parse_procfile ... ok
12:39:01 system     | each_handle_exec_and_output.1 start at pid: 11774
test stream_read::tests::test_new ... ok
12:39:01 system     | sending SIGTERM for check_for_child_termination_thread-1 at pid 11769
12:39:01 system     | sending SIGTERM for check_for_child_termination_thread-2 at pid 11771
12:39:01 check_for_child_termination_thread-2 | terminated by SIGTERM
12:39:01 check_for_child_termination_thread-1 | terminated by SIGTERM
trap_signal_at_multithred_1
trap_signal_at_multithred_2
12:39:02 each_handle_exec_and_output.1 | Hello World 1
trap_signal_at_multithred_1
trap_signal_at_multithred_2
12:39:03 each_handle_exec_and_output.1 | Hello World 2
trap_signal_at_multithred_2
trap_signal_at_multithred_1
test output::tests::test_handle_output ... ok
12:39:04 each_handle_exec_and_output.1 | Hello World 3
test process::tests::test_each_handle_exec_and_output ... ok
trap_signal_at_multithred_1
trap_signal_at_multithred_2
12:39:06 system   | SIGINT received, starting shutdown
12:39:06 system     | sending SIGTERM to all processes
12:39:06 system     | sending SIGTERM for trap_signal_at_multithred-1 at pid 11773
12:39:06 system     | sending SIGTERM for trap_signal_at_multithred-2 at pid 11786
thread 'check child terminated' panicked at 'exit 0', src/process.rs:174:17
test process::tests::test_check_for_child_termination_thread ... ok
test signal::tests::test_trap_signal ... ok
thread '<unnamed>' panicked at 'exit 0', src/process.rs:174:17
test signal::tests::test_trap_signal_at_multithred ... ok

test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

```