### PR TITLE
Remove support for windows [skip ci]

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -9,7 +9,8 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04, macOS-latest, windows-latest]
+        # os: [ubuntu-18.04, macOS-latest, windows-latest]
+        os: [ubuntu-18.04, macOS-latest]
         rust: [stable]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,8 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-18.04, macOS-latest, windows-latest]
+        # os: [ubuntu-18.04, macOS-latest, windows-latest]
+        os: [ubuntu-18.04, macOS-latest]
         rust: [stable]
 
     runs-on: ${{ matrix.os }}
@@ -39,9 +40,9 @@ jobs:
       if: matrix.os == 'macOS-latest'
       run: make release_mac
 
-    - name: Build for Windows
-      if: matrix.os == 'windows-latest'
-      run: make release_win
+    # - name: Build for Windows
+    #   if: matrix.os == 'windows-latest'
+    #   run: make release_win
 
     - name: Release
       uses: softprops/action-gh-release@v1

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ So the specifications are exactly the same as ruby ​​`foreman`.
 
 - Linux
 - macOS
-- windows?
+- windows (Do not Support)
 
 ## 🦀 Installation
 


### PR DESCRIPTION
### Summary

It seems that nix cannot be used on windows.
Remove support for windows.

![image](https://user-images.githubusercontent.com/11146767/101986827-b5281100-3cd3-11eb-86ef-d2ec8718733c.png)
