### PR TITLE
Fix cargo for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,8 @@ serde_json = "1.0.59"
 shellwords = "1.1.0"
 signal-hook = "0.1.16"
 structopt = "0.3.20"
-roff = { git = "https://github.com/yukihirop/roff-rs", optional = true }
+# https://doc.rust-lang.org/nightly/cargo/reference/specifying-dependencies.html?highlight=git,version#multiple-locations
+roff = { git = "https://github.com/yukihirop/roff-rs", version = ">=0.1.0", optional = true }
 
 [features]
 man = [ "roff" ]


### PR DESCRIPTION
### Summary

Fix Cargo.toml

### Work

[before]
```bash
$ cargo publish --dry-run
    Updating crates.io index
error: all dependencies must have a version specified when publishing.
dependency `roff` does not specify a version
Note: The published dependency will use the version from crates.io,
the `git` specification will be removed from the dependency declaration.
```

[after]
```bash
cargo publish --dry-run
.
.
.
warning: 1 warning emitted

    Finished dev [unoptimized + debuginfo] target(s) in 32.86s
   Uploading ultraman v0.1.0 (/Users/yukihirop/RustProjects/ultraman)
warning: aborting upload due to dry run
```