### PR TITLE
Fix Fail test in ubuntu

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -7,7 +7,7 @@ on:
   - cron: 0 0 * * SUN
 
 jobs:
-  build:
+  test:
 
     strategy:
       matrix:
@@ -29,3 +29,6 @@ jobs:
       run: |
         cargo update
         cargo test --locked
+      shell: bash
+      env:
+        SHELL: /bin/bash

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Run tests
       run: |
         cargo update
-        cargo test --locked
+        make test
       shell: bash
       env:
         SHELL: /bin/bash

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -5,7 +5,7 @@ name: Regression
 on: [push, pull_request]
 
 jobs:
-  build:
+  test:
 
     strategy:
       matrix:
@@ -27,6 +27,12 @@ jobs:
 
     - name: Run tests
       run: cargo test --locked
+      shell: bash
+      env:
+        SHELL: /bin/bash
 
     - name: Run tests feature variation
       run: cargo test --locked --no-default-features
+      shell: bash
+      env:
+        SHELL: /bin/bash

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -26,13 +26,13 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Run tests
-      run: cargo test --locked
+      run: make test
       shell: bash
       env:
         SHELL: /bin/bash
 
     - name: Run tests feature variation
-      run: cargo test --locked --no-default-features
+      run: make test-no-default-features
       shell: bash
       env:
         SHELL: /bin/bash

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.env
 tmp
 supervisord.log
+/containers/registry

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,11 @@ install_man: create_man
 
 test:
 	cargo test --locked
+	cargo test --locked -- --ignored
+
+test-no-default-features:
+	cargo test --locked --no-default-features
+	cargo test --locked --no-default-features -- --ignored
 
 release_linux:
 	cargo build --locked --release --target=x86_64-unknown-linux-musl

--- a/README.md
+++ b/README.md
@@ -141,10 +141,28 @@ cargo run export --help
 
 ## ✍️ Test
 
+`src/signal.rs` usually ignores tests that need to send a SIGINT to kill the process as it can interrupt other tests
+
 ```bash
 cargo test
+cargo test -- --ignored # unit test about src/signal.rs
 # or
 cargo test -- --nocapture
+```
+
+## 👽 Development in Docker
+
+It is useful when a person developing on mac wants to check the operation on ubuntu.
+
+```bash
+{
+    docker-compose build
+    docker-compose up -d
+    docker exec -it ultraman_test_ubuntu_1 /bin/bash
+}
+
+# in docker
+root@65241fa12c67:/home/app# make test
 ```
 
 ## 🧔 Man

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -1,0 +1,32 @@
+# https://github.com/rust-lang/docker-rust/pull/57/files
+
+FROM buildpack-deps:bionic
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=1.41.0
+
+RUN set -eux; \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+        amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='ad1f8b5199b3b9e231472ed7aa08d2e5d1d539198a15c5b1e53c746aad81d27b' ;; \
+        armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='6c6c3789dabf12171c7f500e06d21d8004b5318a5083df8b0b02c0e5ef1d017b' ;; \
+        arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='26942c80234bac34b3c1352abbd9187d3e23b43dae3cf56a9f9c1ea8ee53076d' ;; \
+        i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='27ae12bc294a34e566579deba3e066245d09b8871dc021ef45fc715dced05297' ;; \
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac; \
+    url="https://static.rust-lang.org/rustup/archive/1.21.1/${rustArch}/rustup-init"; \
+    wget "$url"; \
+    echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version;
+
+ENV APP /home/app
+RUN mkdir -p ${APP}
+WORKDIR ${APP}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.0"
+services:
+  test_ubuntu:
+    build:
+      context: .
+      dockerfile: './containers/Dockerfile'
+    volumes:
+      - .:/home/app
+      - ./containers/registry:/usr/local/cargo/registry/
+    environment:
+      - SHELL=/bin/bash
+    entrypoint: /bin/bash -c "while :; do sleep 10; done"
+    

--- a/man/main.rs
+++ b/man/main.rs
@@ -1,4 +1,4 @@
-#[cfg(feature="man")]
+#[cfg(feature = "man")]
 extern crate roff;
 use roff::*;
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -239,7 +239,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "exit 1: Any")]
+    #[should_panic(expected = "exit 0: Any")]
     fn test_check_for_child_termination_thread() {
         let procs = Arc::new(Mutex::new(vec![
             Arc::new(Mutex::new(Process {
@@ -262,6 +262,6 @@ mod tests {
 
         check_for_child_termination_thread(procs2, padding, true)
             .join()
-            .expect("exit 1");
+            .expect("exit 0");
     }
 }

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -28,33 +28,6 @@ pub fn handle_signal_thread(
     result
 }
 
-pub fn trap_signal(child_id: nix::unistd::Pid) -> Result<(), Box<dyn std::error::Error>> {
-    let signals = Signals::new(&[SIGALRM, SIGHUP, SIGINT, SIGTERM])?;
-
-    for sig in signals.forever() {
-        match sig {
-            SIGINT => {
-                if let Err(e) = signal::kill(child_id, Signal::SIGTERM) {
-                    println!("error: {}", &e);
-
-                    #[cfg(not(test))]
-                    exit(1);
-                    #[cfg(test)]
-                    panic!("exit {}", 1);
-                }
-
-                #[cfg(not(test))]
-                exit(0);
-                #[cfg(test)]
-                panic!("exit 0");
-            }
-            _ => (),
-        }
-    }
-
-    Ok(())
-}
-
 fn trap_signal_at_multithred(
     procs: Arc<Mutex<Vec<Arc<Mutex<Process>>>>>,
     padding: usize,
@@ -212,7 +185,6 @@ pub fn kill_children(
 mod tests {
     use super::*;
     use libc;
-    use nix::unistd::{fork, pause, ForkResult};
     use signal_hook::SIGINT;
     use std::process::Command;
     use std::thread::sleep;
@@ -223,30 +195,6 @@ mod tests {
         unsafe { libc::raise(SIGINT) };
     }
 
-    #[test]
-    #[should_panic(expected = "exit 0")]
-    fn test_trap_signal() {
-        let thread_send_sigint = thread::spawn(move || {
-            sleep(Duration::from_secs(5));
-            send_sigint();
-        });
-
-        unsafe {
-            match fork().expect("failed fork at test_trap_signal") {
-                ForkResult::Child => {
-                    Command::new("./test/fixtures/loop.sh")
-                        .arg("trap_signal")
-                        .spawn()
-                        .expect("failed execute trap_signal");
-                    pause()
-                }
-                ForkResult::Parent { child } => {
-                    trap_signal(child).expect("failed test_trap_signal");
-                    thread_send_sigint.join().expect("failed send sigint");
-                }
-            }
-        }
-    }
 
     #[test]
     #[should_panic(expected = "failed handle signals: Any")]

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -196,7 +196,6 @@ mod tests {
         unsafe { libc::raise(SIGINT) };
     }
 
-
     #[test]
     #[ignore]
     fn test_trap_signal_at_multithred() {

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -181,6 +181,7 @@ pub fn kill_children(
     }
 }
 
+// Tests that need to send a SIGINT to kill the process can interrupt other tests and are usually ignored
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -197,7 +198,7 @@ mod tests {
 
 
     #[test]
-    #[should_panic(expected = "failed handle signals: Any")]
+    #[ignore]
     fn test_trap_signal_at_multithred() {
         let procs = Arc::new(Mutex::new(vec![
             Arc::new(Mutex::new(Process {


### PR DESCRIPTION
### Summary

Resolve #27 


### Work

![image](https://user-images.githubusercontent.com/11146767/103018475-aa4d6600-4588-11eb-8e04-ca39090c3d15.png)


### Test

```bash
$ make test
cargo test --locked
   Compiling ultraman v0.1.0 (/Users/yukihirop/RustProjects/ultraman)
warning: use of deprecated function `dotenv::from_path_iter`: please use `from_path` in conjunction with `var` instead
  --> src/env.rs:10:25
   |
10 |     if let Some(iter) = dotenv::from_path_iter(filepath.as_path()).ok() {
   |                         ^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: 1 warning emitted

    Finished test [unoptimized + debuginfo] target(s) in 3.93s
     Running target/debug/deps/ultraman-30dae6b0a9086ede

running 16 tests
test procfile::tests::test_find_by ... ok
test procfile::tests::test_padding ... ok
test log::tests::test_output_when_not_coloring ... ok
test procfile::tests::test_process_len ... ok
test procfile::tests::test_set_concurrency ... ok
test procfile::tests::test_set_concurrency_all ... ok
test log::tests::test_error ... ok
test log::tests::test_output_when_coloring ... ok
test signal::tests::test_trap_signal_at_multithred ... ignored
test procfile::tests::test_set_concurrency_when_panic ... ok
test env::tests::test_read_env ... ok
01:38:21 system     | each_handle_exec_and_output.1 start at pid: 25328
test procfile::tests::test_parse_procfile ... ok
test stream_read::tests::test_new ... ok
01:38:21 system     | sending SIGTERM for check_for_child_termination_thread-1 at pid 25326
01:38:21 system     | sending SIGTERM for check_for_child_termination_thread-2 at pid 25327
01:38:21 check_for_child_termination_thread-1 | terminated by SIGTERM
01:38:21 check_for_child_termination_thread-2 | terminated by SIGTERM
01:38:22 each_handle_exec_and_output.1 |  1
01:38:23 each_handle_exec_and_output.1 |  2
test output::tests::test_handle_output ... ok
01:38:24 each_handle_exec_and_output.1 |  3
thread 'check child terminated' panicked at 'exit 0', src/process.rs:174:17
test process::tests::test_each_handle_exec_and_output ... ok
test process::tests::test_check_for_child_termination_thread ... ok

test result: ok. 15 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out

cargo test --locked -- --ignored
warning: use of deprecated function `dotenv::from_path_iter`: please use `from_path` in conjunction with `var` instead
  --> src/env.rs:10:25
   |
10 |     if let Some(iter) = dotenv::from_path_iter(filepath.as_path()).ok() {
   |                         ^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: 1 warning emitted

    Finished test [unoptimized + debuginfo] target(s) in 0.05s
     Running target/debug/deps/ultraman-30dae6b0a9086ede

running 1 test
trap_signal_at_multithred_2
trap_signal_at_multithred_1
trap_signal_at_multithred_2
trap_signal_at_multithred_1
trap_signal_at_multithred_1
trap_signal_at_multithred_2
trap_signal_at_multithred_1
trap_signal_at_multithred_2
01:38:29 system   | SIGINT received, starting shutdown
01:38:29 system     | sending SIGTERM to all processes
01:38:29 system     | sending SIGTERM for trap_signal_at_multithred-1 at pid 25348
01:38:29 system     | sending SIGTERM for trap_signal_at_multithred-2 at pid 25349
01:38:30 trap_signal_at_multithred-2 | terminated by SIGTERM
01:38:30 trap_signal_at_multithred-1 | terminated by SIGTERM
01:38:30 system     | exit 0
test signal::tests::test_trap_signal_at_multithred ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 15 filtered out

```