### PR TITLE
Allow homebrew to be town loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## v0.1.1
+
+2020/12/24
+
+- Support to install by homebrew
+
+Please see [milestone v0.1.1](https://github.com/yukihirop/ultraman/milestone/2?closed=1)
+
 ## v0.1.0
 
 2020/12/13

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ GIT_REVISION=$(shell git log -1 --format="%h")
 RUST_VERSION=$(word 2, $(shell rustc -V))
 LONG_VERSION="$(VERSION) ( rev: $(GIT_REVISION), rustc: $(RUST_VERSION), build at: $(BUILD_TIME) )"
 BIN_NAME=ultraman
+BASE_RELEASE_FILES := ./tmp/ultraman.1 README.md LICENSE
 
 export LONG_VERSION
 
@@ -28,15 +29,15 @@ test-no-default-features:
 	cargo test --locked --no-default-features
 	cargo test --locked --no-default-features -- --ignored
 
-release_linux:
+release_linux: create_man
 	cargo build --locked --release --target=x86_64-unknown-linux-musl
-	zip -j ${BIN_NAME}-v${VERSION}-x86_64-linux.zip target/x86_64-unknown-linux-musl/release/${BIN_NAME}
+	zip -j ${BIN_NAME}-v${VERSION}-x86_64-linux.zip target/x86_64-unknown-linux-musl/release/${BIN_NAME} $(strip $(BASE_RELEASE_FILES))
 
-release_win:
+release_win: create_man
 	cargo build --locked --release --target=x86_64-pc-windows-msvc
-	7z a ${BIN_NAME}-v${VERSION}-x86_64-win.zip target/x86_64-pc-windows-msvc/release/${BIN_NAME}.exe
+	7z a ${BIN_NAME}-v${VERSION}-x86_64-win.zip target/x86_64-pc-windows-msvc/release/${BIN_NAME}.exe $(strip $(BASE_RELEASE_FILES))
 
-release_mac:
+release_mac: create_man
 	cargo build --locked --release --target=x86_64-apple-darwin
-	zip -j ${BIN_NAME}-v${VERSION}-x86_64-mac.zip target/x86_64-apple-darwin/release/${BIN_NAME}
+	zip -j ${BIN_NAME}-v${VERSION}-x86_64-mac.zip target/x86_64-apple-darwin/release/${BIN_NAME} $(strip $(BASE_RELEASE_FILES))
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ So the specifications are exactly the same as ruby ​​`foreman`.
 
 ## 🦀 Installation
 
-Download binary
+### Download binary
 
 Download from [release page](https://github.com/yukihirop/ultraman/releases), and extract to the directory in PATH.
 
@@ -22,6 +22,13 @@ If you want to install the `man`,
 ```bash
 git clone git@github.com:yukihirop/ultraman.git && cd ultraman
 make install_man
+```
+
+### Homebrew
+
+```bash
+brew tap yukihirop/homebrew-tap
+brew install ultraman
 ```
 
 ## 💻 Command


### PR DESCRIPTION
### Summary

Resolve #24 

### Work

```bash
$ make release_mac
cargo run --bin man --features man > ./tmp/ultraman.1;
    Finished dev [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/man`
cargo build --locked --release --target=x86_64-apple-darwin
   Compiling ultraman v0.1.0 (/Users/yukihirop/RustProjects/ultraman)
warning: use of deprecated function `dotenv::from_path_iter`: please use `from_path` in conjunction with `var` instead
  --> src/env.rs:10:25
   |
10 |     if let Some(iter) = dotenv::from_path_iter(filepath.as_path()).ok() {
   |                         ^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: 1 warning emitted

    Finished release [optimized] target(s) in 6.17s
zip -j ultraman-v0.1.0-x86_64-mac.zip target/x86_64-apple-darwin/release/ultraman ./tmp/ultraman.1 README.md LICENSE
updating: ultraman (deflated 64%)
updating: ultraman.1 (deflated 68%)
updating: README.md (deflated 63%)
updating: LICENSE (deflated 41%)
```

### Test
