### PR TITLE
Fix fail make create_man

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "ultraman"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ultraman"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["yukihirop <te108186@gmail.com>"]
 repository = "https://github.com/yukihirop/ultraman"
 edition = "2018"

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ export LONG_VERSION
 .PHONY: create_man man install_man test release_linux release_win release_mac
 
 create_man:
-	cargo run --bin man --features man > ./tmp/ultraman.1;
+	if [ ! -d ./tmp ]; then mkdir ./tmp; fi && cargo run --bin man --features man > ./tmp/ultraman.1;
 
 man: create_man
 	man ./tmp/ultraman.1;


### PR DESCRIPTION
### Summary

- Resolve #32
- bump v0.1.1

### Work

```bash
$ make create_man
if [ ! -d ./tmp ]; then mkdir ./tmp; fi && cargo run --bin man --features man > ./tmp/ultraman.1;
   Compiling ultraman v0.1.1 (/Users/yukihirop/RustProjects/ultraman)
    Finished dev [unoptimized + debuginfo] target(s) in 1.09s
     Running `target/debug/man`
```

### Test
