### PR TITLE
Refactor All

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ Download from [release page](https://github.com/yukihirop/ultraman/releases), an
 
 If you want to install the `man`,
 
+Suppose you unzip the archive in the `./tmp` directory
+
+```bash
+install -Dm644 ./tmp/ultraman.1 /usr/local/share/man/man1/ultraman.1
+```
+
+or
+
 ```bash
 git clone git@github.com:yukihirop/ultraman.git && cd ultraman
 make install_man

--- a/src/cmd/export/base.rs
+++ b/src/cmd/export/base.rs
@@ -39,18 +39,23 @@ pub trait Exportable {
     }
 
     fn app(&self) -> String {
-        self.ref_opts().app.clone().unwrap_or_else(|| "app".to_string())
+        self.ref_opts()
+            .app
+            .clone()
+            .unwrap_or_else(|| "app".to_string())
     }
 
     fn log_path(&self) -> PathBuf {
         self.ref_opts()
-            .log_path.clone()
+            .log_path
+            .clone()
             .unwrap_or_else(|| PathBuf::from(format!("/var/log/{}", self.app())))
     }
 
     fn run_path(&self) -> PathBuf {
         self.ref_opts()
-            .run_path.clone()
+            .run_path
+            .clone()
             .unwrap_or_else(|| PathBuf::from(format!("/var/run/{}", self.app())))
     }
 
@@ -60,7 +65,8 @@ pub trait Exportable {
 
     fn root_path(&self) -> PathBuf {
         self.ref_opts()
-            .root_path.clone()
+            .root_path
+            .clone()
             .unwrap_or_else(|| env::current_dir().unwrap())
     }
 
@@ -89,19 +95,22 @@ pub trait Exportable {
         println!("[ultraman export] {}", msg)
     }
 
-    fn write_template(
-        &self,
-        tmpl: Template,
-    ) {
+    fn write_template(&self, tmpl: Template) {
         let handlebars = Handlebars::new();
-        let display_template = tmpl.template_path
+        let display_template = tmpl
+            .template_path
             .clone()
             .into_os_string()
             .into_string()
             .unwrap();
-        let display_output = tmpl.output_path.clone().into_os_string().into_string().unwrap();
-        let mut template_source =
-            File::open(tmpl.template_path).expect(&format!("Could not open file: {}", display_template));
+        let display_output = tmpl
+            .output_path
+            .clone()
+            .into_os_string()
+            .into_string()
+            .unwrap();
+        let mut template_source = File::open(tmpl.template_path)
+            .expect(&format!("Could not open file: {}", display_template));
         let mut output_file = File::create(tmpl.output_path)
             .expect(&format!("Could not create file: {}", &display_output));
         self.say(&format!("writing: {}", &display_output));

--- a/src/cmd/export/base.rs
+++ b/src/cmd/export/base.rs
@@ -91,24 +91,23 @@ pub trait Exportable {
 
     fn write_template(
         &self,
-        template_path: &PathBuf,
-        data: &mut Map<String, Json>,
-        output_path: &PathBuf,
+        tmpl: Template,
     ) {
         let handlebars = Handlebars::new();
-        let display_template = template_path
+        let display_template = tmpl.template_path
             .clone()
             .into_os_string()
             .into_string()
             .unwrap();
-        let display_output = output_path.clone().into_os_string().into_string().unwrap();
+        let display_output = tmpl.output_path.clone().into_os_string().into_string().unwrap();
         let mut template_source =
-            File::open(template_path).expect(&format!("Could not open file: {}", display_template));
-        let mut output_file = File::create(output_path)
+            File::open(tmpl.template_path).expect(&format!("Could not open file: {}", display_template));
+        let mut output_file = File::create(tmpl.output_path)
             .expect(&format!("Could not create file: {}", &display_output));
         self.say(&format!("writing: {}", &display_output));
+        let mut data = tmpl.data;
         handlebars
-            .render_template_source_to_write(&mut template_source, data, &mut output_file)
+            .render_template_source_to_write(&mut template_source, &mut data, &mut output_file)
             .expect(&format!("Coult not render file: {}", &display_output));
     }
 

--- a/src/cmd/export/base.rs
+++ b/src/cmd/export/base.rs
@@ -19,10 +19,10 @@ pub struct EnvParameter {
 pub trait Exportable {
     fn export(&self) -> Result<(), Box<dyn std::error::Error>>;
     //https://yajamon.hatenablog.com/entry/2018/01/30/202849
-    fn opts(&self) -> ExportOpts;
+    fn ref_opts(&self) -> &ExportOpts;
 
     fn base_export(&self) -> Result<(), Box<dyn std::error::Error>> {
-        let opts = self.opts();
+        let opts = self.ref_opts();
         let location = &opts.location;
         let display = location.clone().into_os_string().into_string().unwrap();
         create_dir_all(&location).expect(&format!("Could not create: {}", display));
@@ -33,28 +33,28 @@ pub trait Exportable {
     }
 
     fn app(&self) -> String {
-        self.opts().app.unwrap_or_else(|| "app".to_string())
+        self.ref_opts().app.clone().unwrap_or_else(|| "app".to_string())
     }
 
     fn log_path(&self) -> PathBuf {
-        self.opts()
-            .log_path
+        self.ref_opts()
+            .log_path.clone()
             .unwrap_or_else(|| PathBuf::from(format!("/var/log/{}", self.app())))
     }
 
     fn run_path(&self) -> PathBuf {
-        self.opts()
-            .run_path
+        self.ref_opts()
+            .run_path.clone()
             .unwrap_or_else(|| PathBuf::from(format!("/var/run/{}", self.app())))
     }
 
     fn username(&self) -> String {
-        self.opts().user.unwrap_or_else(|| self.app())
+        self.ref_opts().user.clone().unwrap_or_else(|| self.app())
     }
 
     fn root_path(&self) -> PathBuf {
-        self.opts()
-            .root_path
+        self.ref_opts()
+            .root_path.clone()
             .unwrap_or_else(|| env::current_dir().unwrap())
     }
 
@@ -107,12 +107,12 @@ pub trait Exportable {
     }
 
     fn output_path(&self, filename: String) -> PathBuf {
-        let location = self.opts().location;
+        let location = self.ref_opts().location.clone();
         location.join(filename)
     }
 
     fn env_without_port(&self) -> Vec<EnvParameter> {
-        let mut env = read_env(self.opts().env_path).expect("failed read .env");
+        let mut env = read_env(self.ref_opts().env_path.clone()).expect("failed read .env");
         env.remove("PORT");
         let mut env_without_port: Vec<EnvParameter> = vec![];
         for (key, value) in env {

--- a/src/cmd/export/base.rs
+++ b/src/cmd/export/base.rs
@@ -16,6 +16,12 @@ pub struct EnvParameter {
     pub(crate) value: String,
 }
 
+pub struct Template {
+    pub(crate) template_path: PathBuf,
+    pub(crate) data: Map<String, Json>,
+    pub(crate) output_path: PathBuf,
+}
+
 pub trait Exportable {
     fn export(&self) -> Result<(), Box<dyn std::error::Error>>;
     //https://yajamon.hatenablog.com/entry/2018/01/30/202849

--- a/src/cmd/export/daemon.rs
+++ b/src/cmd/export/daemon.rs
@@ -1,4 +1,4 @@
-use super::base::{EnvParameter, Exportable};
+use super::base::{EnvParameter, Exportable, Template};
 use crate::cmd::export::ExportOpts;
 use crate::env::read_env;
 use crate::process::port_for;
@@ -177,10 +177,17 @@ impl Exportable for Exporter {
     fn export(&self) -> Result<(), Box<dyn std::error::Error>> {
         self.base_export().expect("failed execute base_export");
 
-        let mut data = self.make_master_data();
+        let mut clean_paths: Vec<PathBuf> = vec![];
+        let mut tmpl_data: Vec<Template> = vec![];
+
         let output_path = self.opts.location.join(format!("{}.conf", self.app()));
-        self.clean(&output_path);
-        self.write_template(&self.master_tmpl_path(), &mut data, &output_path);
+
+        clean_paths.push(output_path.clone());
+        tmpl_data.push(Template{
+            template_path: self.master_tmpl_path(),
+            data: self.make_master_data(),
+            output_path,
+        });
 
         let mut index = 0;
         for (name, pe) in self.procfile.data.iter() {
@@ -190,18 +197,35 @@ impl Exportable for Exporter {
                 .opts
                 .location
                 .join(format!("{}-{}.conf", self.app(), &name));
-            let mut data = self.make_process_master_data();
-            self.clean(&output_path);
-            self.write_template(&self.process_master_tmpl_path(), &mut data, &output_path);
+
+            clean_paths.push(output_path.clone());
+            tmpl_data.push(Template{
+                template_path: self.process_master_tmpl_path(),
+                data: self.make_process_master_data(),
+                output_path,
+            });
 
             for n in 0..con {
                 index += 1;
                 let process_name = format!("{}-{}-{}.conf", self.app(), &name, n + 1);
                 let output_path = self.opts.location.join(&process_name);
-                let mut data = self.make_process_data(pe, &service_name, index, n);
-                self.clean(&output_path);
-                self.write_template(&self.process_tmpl_path(), &mut data, &output_path);
+
+                clean_paths.push(output_path.clone());
+                tmpl_data.push(Template{
+                    template_path: self.process_tmpl_path(),
+                    data: self.make_process_data(pe, &service_name, index, n),
+                    output_path,
+                });
             }
+        }
+
+        for path in clean_paths {
+            self.clean(&path);
+        }
+
+        for tmpl in tmpl_data {
+            let mut data = tmpl.data;
+            self.write_template(&tmpl.template_path, &mut data, &tmpl.output_path);
         }
 
         Ok(())

--- a/src/cmd/export/daemon.rs
+++ b/src/cmd/export/daemon.rs
@@ -59,7 +59,7 @@ impl Default for Exporter {
                 procfile_path: PathBuf::from("Procfile"),
                 root_path: Some(env::current_dir().unwrap()),
                 timeout: String::from("5"),
-            }
+            },
         }
     }
 }
@@ -157,7 +157,12 @@ impl Exporter {
     }
 
     fn environment(&self, index: usize, con_index: usize) -> Vec<EnvParameter> {
-        let port = port_for(self.opts.env_path.clone(), self.opts.port.clone(), index, con_index + 1);
+        let port = port_for(
+            self.opts.env_path.clone(),
+            self.opts.port.clone(),
+            index,
+            con_index + 1,
+        );
         let mut env = read_env(self.opts.env_path.clone()).expect("failed read .env");
         env.insert("PORT".to_string(), port);
 
@@ -183,7 +188,7 @@ impl Exportable for Exporter {
         let output_path = self.opts.location.join(format!("{}.conf", self.app()));
 
         clean_paths.push(output_path.clone());
-        tmpl_data.push(Template{
+        tmpl_data.push(Template {
             template_path: self.master_tmpl_path(),
             data: self.make_master_data(),
             output_path,
@@ -199,7 +204,7 @@ impl Exportable for Exporter {
                 .join(format!("{}-{}.conf", self.app(), &name));
 
             clean_paths.push(output_path.clone());
-            tmpl_data.push(Template{
+            tmpl_data.push(Template {
                 template_path: self.process_master_tmpl_path(),
                 data: self.make_process_master_data(),
                 output_path,
@@ -211,7 +216,7 @@ impl Exportable for Exporter {
                 let output_path = self.opts.location.join(&process_name);
 
                 clean_paths.push(output_path.clone());
-                tmpl_data.push(Template{
+                tmpl_data.push(Template {
                     template_path: self.process_tmpl_path(),
                     data: self.make_process_data(pe, &service_name, index, n),
                     output_path,

--- a/src/cmd/export/daemon.rs
+++ b/src/cmd/export/daemon.rs
@@ -207,7 +207,7 @@ impl Exportable for Exporter {
         Ok(())
     }
 
-    fn opts(&self) -> ExportOpts {
-        self.opts.clone()
+    fn ref_opts(&self) -> &ExportOpts {
+        &self.opts
     }
 }

--- a/src/cmd/export/daemon.rs
+++ b/src/cmd/export/daemon.rs
@@ -224,8 +224,7 @@ impl Exportable for Exporter {
         }
 
         for tmpl in tmpl_data {
-            let mut data = tmpl.data;
-            self.write_template(&tmpl.template_path, &mut data, &tmpl.output_path);
+            self.write_template(tmpl);
         }
 
         Ok(())

--- a/src/cmd/export/launchd.rs
+++ b/src/cmd/export/launchd.rs
@@ -135,7 +135,7 @@ impl Exportable for Exporter {
         Ok(())
     }
 
-    fn opts(&self) -> ExportOpts {
-        self.opts.clone()
+    fn ref_opts(&self) -> &ExportOpts {
+        &self.opts
     }
 }

--- a/src/cmd/export/launchd.rs
+++ b/src/cmd/export/launchd.rs
@@ -144,8 +144,7 @@ impl Exportable for Exporter {
         }
 
         for tmpl in tmpl_data {
-            let mut data = tmpl.data;
-            self.write_template(&tmpl.template_path, &mut data, &tmpl.output_path);
+            self.write_template(tmpl);
         }
 
         Ok(())

--- a/src/cmd/export/launchd.rs
+++ b/src/cmd/export/launchd.rs
@@ -46,7 +46,7 @@ impl Default for Exporter {
                 procfile_path: PathBuf::from("Procfile"),
                 root_path: Some(env::current_dir().unwrap()),
                 timeout: String::from("5"),
-            }
+            },
         }
     }
 }
@@ -99,7 +99,12 @@ impl Exporter {
     }
 
     fn environment(&self, index: usize, con_index: usize) -> Vec<EnvParameter> {
-        let port = port_for(self.opts.env_path.clone(), self.opts.port.clone(), index, con_index + 1);
+        let port = port_for(
+            self.opts.env_path.clone(),
+            self.opts.port.clone(),
+            index,
+            con_index + 1,
+        );
         let mut env = read_env(self.opts.env_path.clone()).expect("failed read .env");
         env.insert("PORT".to_string(), port);
 
@@ -131,7 +136,7 @@ impl Exportable for Exporter {
                 let output_path = self.opts.location.join(&service_name);
 
                 clean_paths.push(output_path.clone());
-                tmpl_data.push(Template{
+                tmpl_data.push(Template {
                     template_path: self.launchd_tmpl_path(),
                     data: self.make_launchd_data(pe, &service_name, index, n),
                     output_path,

--- a/src/cmd/export/launchd.rs
+++ b/src/cmd/export/launchd.rs
@@ -12,20 +12,7 @@ use std::path::PathBuf;
 
 pub struct Exporter {
     pub procfile: Procfile,
-    // ExportOpts
-    pub format: String,
-    pub location: PathBuf,
-    pub app: Option<String>,
-    pub formation: String,
-    pub log_path: Option<PathBuf>,
-    pub run_path: Option<PathBuf>,
-    pub port: Option<String>,
-    pub template_path: Option<PathBuf>,
-    pub user: Option<String>,
-    pub env_path: PathBuf,
-    pub procfile_path: PathBuf,
-    pub root_path: Option<PathBuf>,
-    pub timeout: String,
+    pub opts: ExportOpts,
 }
 
 #[derive(Serialize)]
@@ -45,19 +32,21 @@ impl Default for Exporter {
             procfile: Procfile {
                 data: HashMap::new(),
             },
-            format: String::from(""),
-            location: PathBuf::from("location"),
-            app: None,
-            formation: String::from("all=1"),
-            log_path: None,
-            run_path: None,
-            port: None,
-            template_path: None,
-            user: None,
-            env_path: PathBuf::from(".env"),
-            procfile_path: PathBuf::from("Procfile"),
-            root_path: Some(env::current_dir().unwrap()),
-            timeout: String::from("5"),
+            opts: ExportOpts {
+                format: String::from(""),
+                location: PathBuf::from("location"),
+                app: None,
+                formation: String::from("all=1"),
+                log_path: None,
+                run_path: None,
+                port: None,
+                template_path: None,
+                user: None,
+                env_path: PathBuf::from(".env"),
+                procfile_path: PathBuf::from("Procfile"),
+                root_path: Some(env::current_dir().unwrap()),
+                timeout: String::from("5"),
+            }
         }
     }
 }
@@ -110,8 +99,8 @@ impl Exporter {
     }
 
     fn environment(&self, index: usize, con_index: usize) -> Vec<EnvParameter> {
-        let port = port_for(self.opts().env_path, self.opts().port, index, con_index + 1);
-        let mut env = read_env(self.opts().env_path).expect("failed read .env");
+        let port = port_for(self.opts.env_path.clone(), self.opts.port.clone(), index, con_index + 1);
+        let mut env = read_env(self.opts.env_path.clone()).expect("failed read .env");
         env.insert("PORT".to_string(), port);
 
         let mut result = vec![];
@@ -136,7 +125,7 @@ impl Exportable for Exporter {
             for n in 0..con {
                 index += 1;
                 let service_name = format!("{}-{}-{}", self.app(), &name, n + 1);
-                let output_path = self.opts().location.join(&service_name);
+                let output_path = self.opts.location.join(&service_name);
                 let mut data = self.make_launchd_data(pe, &service_name, index, n);
                 self.clean(&output_path);
                 self.write_template(&self.launchd_tmpl_path(), &mut data, &output_path);
@@ -147,20 +136,6 @@ impl Exportable for Exporter {
     }
 
     fn opts(&self) -> ExportOpts {
-        ExportOpts {
-            format: self.format.clone(),
-            location: self.location.clone(),
-            app: self.app.clone(),
-            formation: self.formation.clone(),
-            log_path: self.log_path.clone(),
-            run_path: self.run_path.clone(),
-            port: self.port.clone(),
-            template_path: self.template_path.clone(),
-            user: self.user.clone(),
-            env_path: self.env_path.clone(),
-            procfile_path: self.procfile_path.clone(),
-            root_path: self.root_path.clone(),
-            timeout: self.timeout.clone(),
-        }
+        self.opts.clone()
     }
 }

--- a/src/cmd/export/mod.rs
+++ b/src/cmd/export/mod.rs
@@ -11,7 +11,7 @@ pub mod supervisord;
 pub mod systemd;
 pub mod upstart;
 
-#[derive(StructOpt, Debug, Default)]
+#[derive(StructOpt, Debug, Default, Clone)]
 #[structopt(setting(clap::AppSettings::ColoredHelp))]
 pub struct ExportOpts {
     /// Specify  process management format
@@ -115,114 +115,42 @@ fn new(opts: &ExportOpts) -> Box<dyn Exportable> {
             // Read the formation from the command line option and always call it before process_len for the convenience of setting concurrency
             procfile.set_concurrency(&opts.formation);
             expo.procfile = procfile;
-            expo.format = opts.format.clone();
-            expo.location = opts.location.clone();
-            expo.app = opts.app.clone();
-            expo.formation = opts.formation.clone();
-            expo.log_path = opts.log_path.clone();
-            expo.run_path = opts.run_path.clone();
-            expo.port = opts.port.clone();
-            expo.template_path = opts.template_path.clone();
-            expo.user = opts.user.clone();
-            expo.env_path = opts.env_path.clone();
-            expo.procfile_path = opts.procfile_path.clone();
-            expo.root_path = opts.root_path.clone();
-            expo.timeout = opts.timeout.clone();
+            expo.opts = opts.clone();
             expo
         }
         ExportFormat::Systemd => {
             let mut expo = systemd::Exporter::boxed_new();
             procfile.set_concurrency(&opts.formation);
             expo.procfile = procfile;
-            expo.format = opts.format.clone();
-            expo.location = opts.location.clone();
-            expo.app = opts.app.clone();
-            expo.formation = opts.formation.clone();
-            expo.log_path = opts.log_path.clone();
-            expo.run_path = opts.run_path.clone();
-            expo.port = opts.port.clone();
-            expo.template_path = opts.template_path.clone();
-            expo.user = opts.user.clone();
-            expo.env_path = opts.env_path.clone();
-            expo.procfile_path = opts.procfile_path.clone();
-            expo.root_path = opts.root_path.clone();
-            expo.timeout = opts.timeout.clone();
+            expo.opts = opts.clone();
             expo
         }
         ExportFormat::Supervisord => {
             let mut expo = supervisord::Exporter::boxed_new();
             procfile.set_concurrency(&opts.formation);
             expo.procfile = procfile;
-            expo.format = opts.format.clone();
-            expo.location = opts.location.clone();
-            expo.app = opts.app.clone();
-            expo.formation = opts.formation.clone();
-            expo.log_path = opts.log_path.clone();
-            expo.run_path = opts.run_path.clone();
-            expo.port = opts.port.clone();
-            expo.template_path = opts.template_path.clone();
-            expo.user = opts.user.clone();
-            expo.env_path = opts.env_path.clone();
-            expo.procfile_path = opts.procfile_path.clone();
-            expo.root_path = opts.root_path.clone();
-            expo.timeout = opts.timeout.clone();
+            expo.opts = opts.clone();
             expo
         }
         ExportFormat::Runit => {
             let mut expo = runit::Exporter::boxed_new();
             procfile.set_concurrency(&opts.formation);
             expo.procfile = procfile;
-            expo.format = opts.format.clone();
-            expo.location = opts.location.clone();
-            expo.app = opts.app.clone();
-            expo.formation = opts.formation.clone();
-            expo.log_path = opts.log_path.clone();
-            expo.run_path = opts.run_path.clone();
-            expo.port = opts.port.clone();
-            expo.template_path = opts.template_path.clone();
-            expo.user = opts.user.clone();
-            expo.env_path = opts.env_path.clone();
-            expo.procfile_path = opts.procfile_path.clone();
-            expo.root_path = opts.root_path.clone();
-            expo.timeout = opts.timeout.clone();
+            expo.opts = opts.clone();
             expo
         }
         ExportFormat::Launchd => {
             let mut expo = launchd::Exporter::boxed_new();
             procfile.set_concurrency(&opts.formation);
             expo.procfile = procfile;
-            expo.format = opts.format.clone();
-            expo.location = opts.location.clone();
-            expo.app = opts.app.clone();
-            expo.formation = opts.formation.clone();
-            expo.log_path = opts.log_path.clone();
-            expo.run_path = opts.run_path.clone();
-            expo.port = opts.port.clone();
-            expo.template_path = opts.template_path.clone();
-            expo.user = opts.user.clone();
-            expo.env_path = opts.env_path.clone();
-            expo.procfile_path = opts.procfile_path.clone();
-            expo.root_path = opts.root_path.clone();
-            expo.timeout = opts.timeout.clone();
+            expo.opts = opts.clone();
             expo
         }
         ExportFormat::Daemon => {
             let mut expo = daemon::Exporter::boxed_new();
             procfile.set_concurrency(&opts.formation);
             expo.procfile = procfile;
-            expo.format = opts.format.clone();
-            expo.location = opts.location.clone();
-            expo.app = opts.app.clone();
-            expo.formation = opts.formation.clone();
-            expo.log_path = opts.log_path.clone();
-            expo.run_path = opts.run_path.clone();
-            expo.port = opts.port.clone();
-            expo.template_path = opts.template_path.clone();
-            expo.user = opts.user.clone();
-            expo.env_path = opts.env_path.clone();
-            expo.procfile_path = opts.procfile_path.clone();
-            expo.root_path = opts.root_path.clone();
-            expo.timeout = opts.timeout.clone();
+            expo.opts = opts.clone();
             expo
         }
     }

--- a/src/cmd/export/runit.rs
+++ b/src/cmd/export/runit.rs
@@ -14,20 +14,7 @@ use std::path::PathBuf;
 
 pub struct Exporter {
     pub procfile: Procfile,
-    // ExportOpts
-    pub format: String,
-    pub location: PathBuf,
-    pub app: Option<String>,
-    pub formation: String,
-    pub log_path: Option<PathBuf>,
-    pub run_path: Option<PathBuf>,
-    pub port: Option<String>,
-    pub template_path: Option<PathBuf>,
-    pub user: Option<String>,
-    pub env_path: PathBuf,
-    pub procfile_path: PathBuf,
-    pub root_path: Option<PathBuf>,
-    pub timeout: String,
+    pub opts: ExportOpts,
 }
 
 #[derive(Serialize)]
@@ -50,19 +37,21 @@ impl Default for Exporter {
             procfile: Procfile {
                 data: HashMap::new(),
             },
-            format: String::from(""),
-            location: PathBuf::from("location"),
-            app: None,
-            formation: String::from("all=1"),
-            log_path: None,
-            run_path: None,
-            port: None,
-            template_path: None,
-            user: None,
-            env_path: PathBuf::from(".env"),
-            procfile_path: PathBuf::from("Procfile"),
-            root_path: Some(env::current_dir().unwrap()),
-            timeout: String::from("5"),
+            opts: ExportOpts {
+                format: String::from(""),
+                location: PathBuf::from("location"),
+                app: None,
+                formation: String::from("all=1"),
+                log_path: None,
+                run_path: None,
+                port: None,
+                template_path: None,
+                user: None,
+                env_path: PathBuf::from(".env"),
+                procfile_path: PathBuf::from("Procfile"),
+                root_path: Some(env::current_dir().unwrap()),
+                timeout: String::from("5"),
+            }
         }
     }
 }
@@ -118,8 +107,8 @@ impl Exporter {
     }
 
     fn write_env(&self, output_dir_path: &PathBuf, index: usize, con_index: usize) {
-        let mut env = read_env(self.opts().env_path).expect("failed read .env");
-        let port = port_for(self.opts().env_path, self.opts().port, index, con_index + 1);
+        let mut env = read_env(self.opts.env_path.clone()).expect("failed read .env");
+        let port = port_for(self.opts.env_path.clone(), self.opts.port.clone(), index, con_index + 1);
         env.insert("PORT".to_string(), port);
 
         for (key, val) in env.iter() {
@@ -145,7 +134,7 @@ impl Exportable for Exporter {
                 index += 1;
                 let process_name = format!("{}-{}", &name, n + 1);
                 let service_name = format!("{}-{}-{}", self.app(), &name, n + 1);
-                let mut path_for_run = self.opts().location;
+                let mut path_for_run = self.opts.location.clone();
                 let mut path_for_env = path_for_run.clone();
                 let mut path_for_log = path_for_run.clone();
                 let run_file_path = PathBuf::from(format!("{}/run", &service_name));
@@ -178,20 +167,6 @@ impl Exportable for Exporter {
     }
 
     fn opts(&self) -> ExportOpts {
-        ExportOpts {
-            format: self.format.clone(),
-            location: self.location.clone(),
-            app: self.app.clone(),
-            formation: self.formation.clone(),
-            log_path: self.log_path.clone(),
-            run_path: self.run_path.clone(),
-            port: self.port.clone(),
-            template_path: self.template_path.clone(),
-            user: self.user.clone(),
-            env_path: self.env_path.clone(),
-            procfile_path: self.procfile_path.clone(),
-            root_path: self.root_path.clone(),
-            timeout: self.timeout.clone(),
-        }
+        self.opts.clone()
     }
 }

--- a/src/cmd/export/runit.rs
+++ b/src/cmd/export/runit.rs
@@ -166,7 +166,7 @@ impl Exportable for Exporter {
         Ok(())
     }
 
-    fn opts(&self) -> ExportOpts {
-        self.opts.clone()
+    fn ref_opts(&self) -> &ExportOpts {
+        &self.opts
     }
 }

--- a/src/cmd/export/runit.rs
+++ b/src/cmd/export/runit.rs
@@ -195,8 +195,7 @@ impl Exportable for Exporter {
         }
 
         for tmpl in tmpl_data {
-            let mut data = tmpl.data;
-            self.write_template(&tmpl.template_path, &mut data, &tmpl.output_path);
+            self.write_template(tmpl);
         }
 
         for e in env_data {

--- a/src/cmd/export/runit.rs
+++ b/src/cmd/export/runit.rs
@@ -51,7 +51,7 @@ impl Default for Exporter {
                 procfile_path: PathBuf::from("Procfile"),
                 root_path: Some(env::current_dir().unwrap()),
                 timeout: String::from("5"),
-            }
+            },
         }
     }
 }
@@ -108,7 +108,12 @@ impl Exporter {
 
     fn write_env(&self, output_dir_path: &PathBuf, index: usize, con_index: usize) {
         let mut env = read_env(self.opts.env_path.clone()).expect("failed read .env");
-        let port = port_for(self.opts.env_path.clone(), self.opts.port.clone(), index, con_index + 1);
+        let port = port_for(
+            self.opts.env_path.clone(),
+            self.opts.port.clone(),
+            index,
+            con_index + 1,
+        );
         env.insert("PORT".to_string(), port);
 
         for (key, val) in env.iter() {
@@ -154,7 +159,7 @@ impl Exportable for Exporter {
                 path_for_run.push(run_file_path);
                 path_for_env.push(env_dir_path);
                 path_for_log.push(log_dir_path);
-                
+
                 create_recursive_dir_paths.push(path_for_env.clone());
                 create_recursive_dir_paths.push(path_for_log.clone());
 
@@ -165,7 +170,7 @@ impl Exportable for Exporter {
                 let log_run_data = self.make_log_run_data(&process_name);
 
                 clean_paths.push(path_for_run.clone());
-                tmpl_data.push(Template{
+                tmpl_data.push(Template {
                     template_path: self.run_tmpl_path(),
                     data: run_data,
                     output_path: path_for_run,
@@ -173,15 +178,15 @@ impl Exportable for Exporter {
 
                 path_for_log.push("run");
                 clean_paths.push(path_for_log.clone());
-                tmpl_data.push(Template{
+                tmpl_data.push(Template {
                     template_path: self.log_run_tmpl_path(),
                     data: log_run_data,
-                    output_path: path_for_log
+                    output_path: path_for_log,
                 });
-                env_data.push(EnvTemplate{
+                env_data.push(EnvTemplate {
                     template_path: path_for_env.clone(),
                     index,
-                    con_index: n
+                    con_index: n,
                 });
             }
         }

--- a/src/cmd/export/supervisord.rs
+++ b/src/cmd/export/supervisord.rs
@@ -1,4 +1,4 @@
-use super::base::Exportable;
+use super::base::{Exportable, Template};
 use crate::cmd::export::ExportOpts;
 use crate::env::read_env;
 use crate::process::port_for;
@@ -145,9 +145,12 @@ impl Exportable for Exporter {
         }
 
         let output_path = self.output_path("app.conf".to_string());
-        let mut data = self.make_app_conf_data(service_names, data);
         self.clean(&output_path);
-        self.write_template(&self.app_conf_tmpl_path(), &mut data, &output_path);
+        self.write_template(Template{
+            template_path: self.app_conf_tmpl_path(),
+            data: self.make_app_conf_data(service_names, data),
+            output_path,
+        });
 
         Ok(())
     }

--- a/src/cmd/export/supervisord.rs
+++ b/src/cmd/export/supervisord.rs
@@ -152,7 +152,7 @@ impl Exportable for Exporter {
         Ok(())
     }
 
-    fn opts(&self) -> ExportOpts {
-        self.opts.clone()
+    fn ref_opts(&self) -> &ExportOpts {
+        &self.opts
     }
 }

--- a/src/cmd/export/supervisord.rs
+++ b/src/cmd/export/supervisord.rs
@@ -57,7 +57,7 @@ impl Default for Exporter {
                 procfile_path: PathBuf::from("Procfile"),
                 root_path: Some(env::current_dir().unwrap()),
                 timeout: String::from("5"),
-            }
+            },
         }
     }
 }
@@ -94,7 +94,12 @@ impl Exporter {
     }
 
     fn environment(&self, index: usize, con_index: usize) -> String {
-        let port = port_for(self.opts.env_path.clone(), self.opts.port.clone(), index, con_index + 1);
+        let port = port_for(
+            self.opts.env_path.clone(),
+            self.opts.port.clone(),
+            index,
+            con_index + 1,
+        );
         let mut env = read_env(self.opts.env_path.clone()).expect("failed read .env");
         env.insert("PORT".to_string(), port);
 
@@ -146,7 +151,7 @@ impl Exportable for Exporter {
 
         let output_path = self.output_path("app.conf".to_string());
         self.clean(&output_path);
-        self.write_template(Template{
+        self.write_template(Template {
             template_path: self.app_conf_tmpl_path(),
             data: self.make_app_conf_data(service_names, data),
             output_path,

--- a/src/cmd/export/supervisord.rs
+++ b/src/cmd/export/supervisord.rs
@@ -16,20 +16,7 @@ const ENV_REGEXP: &'static str = "\\$\\{*(?P<envname>[A-Za-z0-9_-]+)\\}*";
 
 pub struct Exporter {
     pub procfile: Procfile,
-    // ExportOpts
-    pub format: String,
-    pub location: PathBuf,
-    pub app: Option<String>,
-    pub formation: String,
-    pub log_path: Option<PathBuf>,
-    pub run_path: Option<PathBuf>,
-    pub port: Option<String>,
-    pub template_path: Option<PathBuf>,
-    pub user: Option<String>,
-    pub env_path: PathBuf,
-    pub procfile_path: PathBuf,
-    pub root_path: Option<PathBuf>,
-    pub timeout: String,
+    pub opts: ExportOpts,
 }
 
 #[derive(Serialize)]
@@ -56,19 +43,21 @@ impl Default for Exporter {
             procfile: Procfile {
                 data: HashMap::new(),
             },
-            format: String::from(""),
-            location: PathBuf::from("location"),
-            app: None,
-            formation: String::from("all=1"),
-            log_path: None,
-            run_path: None,
-            port: None,
-            template_path: None,
-            user: None,
-            env_path: PathBuf::from(".env"),
-            procfile_path: PathBuf::from("Procfile"),
-            root_path: Some(env::current_dir().unwrap()),
-            timeout: String::from("5"),
+            opts: ExportOpts {
+                format: String::from(""),
+                location: PathBuf::from("location"),
+                app: None,
+                formation: String::from("all=1"),
+                log_path: None,
+                run_path: None,
+                port: None,
+                template_path: None,
+                user: None,
+                env_path: PathBuf::from(".env"),
+                procfile_path: PathBuf::from("Procfile"),
+                root_path: Some(env::current_dir().unwrap()),
+                timeout: String::from("5"),
+            }
         }
     }
 }
@@ -105,8 +94,8 @@ impl Exporter {
     }
 
     fn environment(&self, index: usize, con_index: usize) -> String {
-        let port = port_for(self.opts().env_path, self.opts().port, index, con_index + 1);
-        let mut env = read_env(self.opts().env_path).expect("failed read .env");
+        let port = port_for(self.opts.env_path.clone(), self.opts.port.clone(), index, con_index + 1);
+        let mut env = read_env(self.opts.env_path.clone()).expect("failed read .env");
         env.insert("PORT".to_string(), port);
 
         let mut result = vec![];
@@ -164,20 +153,6 @@ impl Exportable for Exporter {
     }
 
     fn opts(&self) -> ExportOpts {
-        ExportOpts {
-            format: self.format.clone(),
-            location: self.location.clone(),
-            app: self.app.clone(),
-            formation: self.formation.clone(),
-            log_path: self.log_path.clone(),
-            run_path: self.run_path.clone(),
-            port: self.port.clone(),
-            template_path: self.template_path.clone(),
-            user: self.user.clone(),
-            env_path: self.env_path.clone(),
-            procfile_path: self.procfile_path.clone(),
-            root_path: self.root_path.clone(),
-            timeout: self.timeout.clone(),
-        }
+        self.opts.clone()
     }
 }

--- a/src/cmd/export/systemd.rs
+++ b/src/cmd/export/systemd.rs
@@ -141,7 +141,7 @@ impl Exportable for Exporter {
         Ok(())
     }
 
-    fn opts(&self) -> ExportOpts {
-        self.opts.clone()
+    fn ref_opts(&self) -> &ExportOpts {
+        &self.opts
     }
 }

--- a/src/cmd/export/systemd.rs
+++ b/src/cmd/export/systemd.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 
 pub struct Exporter {
     pub procfile: Procfile,
-    pub opts: ExportOpts
+    pub opts: ExportOpts,
 }
 
 #[derive(Serialize)]
@@ -51,7 +51,7 @@ impl Default for Exporter {
                 procfile_path: PathBuf::from("Procfile"),
                 root_path: Some(env::current_dir().unwrap()),
                 timeout: String::from("5"),
-            }
+            },
         }
     }
 }
@@ -100,7 +100,12 @@ impl Exporter {
             app: self.app(),
             user: self.username(),
             work_dir: self.root_path().into_os_string().into_string().unwrap(),
-            port: port_for(self.opts.env_path.clone(), self.opts.port.clone(), index, con_index + 1),
+            port: port_for(
+                self.opts.env_path.clone(),
+                self.opts.port.clone(),
+                index,
+                con_index + 1,
+            ),
             process_name: process_name.to_string(),
             process_command: pe.command.to_string(),
             env_without_port: self.env_without_port(),
@@ -130,10 +135,10 @@ impl Exportable for Exporter {
                 let data = self.make_process_service_data(pe, &process_name, index, n);
 
                 clean_paths.push(output_path.clone());
-                tmpl_data.push(Template{
+                tmpl_data.push(Template {
                     template_path: self.process_service_tmpl_path(),
                     data,
-                    output_path
+                    output_path,
                 });
                 service_names.push(service_filename);
             }
@@ -143,10 +148,10 @@ impl Exportable for Exporter {
         let data = self.make_master_target_data(service_names);
 
         clean_paths.push(output_path.clone());
-        tmpl_data.push(Template{
+        tmpl_data.push(Template {
             template_path: self.master_target_tmpl_path(),
             data,
-            output_path
+            output_path,
         });
 
         for path in clean_paths {

--- a/src/cmd/export/systemd.rs
+++ b/src/cmd/export/systemd.rs
@@ -11,20 +11,7 @@ use std::path::PathBuf;
 
 pub struct Exporter {
     pub procfile: Procfile,
-    // ExportOpts
-    pub format: String,
-    pub location: PathBuf,
-    pub app: Option<String>,
-    pub formation: String,
-    pub log_path: Option<PathBuf>,
-    pub run_path: Option<PathBuf>,
-    pub port: Option<String>,
-    pub template_path: Option<PathBuf>,
-    pub user: Option<String>,
-    pub env_path: PathBuf,
-    pub procfile_path: PathBuf,
-    pub root_path: Option<PathBuf>,
-    pub timeout: String,
+    pub opts: ExportOpts
 }
 
 #[derive(Serialize)]
@@ -50,19 +37,21 @@ impl Default for Exporter {
             procfile: Procfile {
                 data: HashMap::new(),
             },
-            format: String::from(""),
-            location: PathBuf::from("location"),
-            app: None,
-            formation: String::from("all=1"),
-            log_path: None,
-            run_path: None,
-            port: None,
-            template_path: None,
-            user: None,
-            env_path: PathBuf::from(".env"),
-            procfile_path: PathBuf::from("Procfile"),
-            root_path: Some(env::current_dir().unwrap()),
-            timeout: String::from("5"),
+            opts: ExportOpts {
+                format: String::from(""),
+                location: PathBuf::from("location"),
+                app: None,
+                formation: String::from("all=1"),
+                log_path: None,
+                run_path: None,
+                port: None,
+                template_path: None,
+                user: None,
+                env_path: PathBuf::from(".env"),
+                procfile_path: PathBuf::from("Procfile"),
+                root_path: Some(env::current_dir().unwrap()),
+                timeout: String::from("5"),
+            }
         }
     }
 }
@@ -111,11 +100,11 @@ impl Exporter {
             app: self.app(),
             user: self.username(),
             work_dir: self.root_path().into_os_string().into_string().unwrap(),
-            port: port_for(self.opts().env_path, self.opts().port, index, con_index + 1),
+            port: port_for(self.opts.env_path.clone(), self.opts.port.clone(), index, con_index + 1),
             process_name: process_name.to_string(),
             process_command: pe.command.to_string(),
             env_without_port: self.env_without_port(),
-            timeout: self.opts().timeout,
+            timeout: self.opts.timeout.clone(),
         };
         data.insert("process_service".to_string(), to_json(&ps));
         data
@@ -153,20 +142,6 @@ impl Exportable for Exporter {
     }
 
     fn opts(&self) -> ExportOpts {
-        ExportOpts {
-            format: self.format.clone(),
-            location: self.location.clone(),
-            app: self.app.clone(),
-            formation: self.formation.clone(),
-            log_path: self.log_path.clone(),
-            run_path: self.run_path.clone(),
-            port: self.port.clone(),
-            template_path: self.template_path.clone(),
-            user: self.user.clone(),
-            env_path: self.env_path.clone(),
-            procfile_path: self.procfile_path.clone(),
-            root_path: self.root_path.clone(),
-            timeout: self.timeout.clone(),
-        }
+        self.opts.clone()
     }
 }

--- a/src/cmd/export/systemd.rs
+++ b/src/cmd/export/systemd.rs
@@ -154,8 +154,7 @@ impl Exportable for Exporter {
         }
 
         for tmpl in tmpl_data {
-            let mut data = tmpl.data;
-            self.write_template(&tmpl.template_path, &mut data, &tmpl.output_path);
+            self.write_template(tmpl);
         }
 
         Ok(())

--- a/src/cmd/export/upstart.rs
+++ b/src/cmd/export/upstart.rs
@@ -166,8 +166,7 @@ impl Exportable for Exporter {
         }
 
         for tmpl in tmpl_data {
-            let mut data = tmpl.data;
-            self.write_template(&tmpl.template_path, &mut data, &tmpl.output_path);
+            self.write_template(tmpl);
         }
 
         Ok(())

--- a/src/cmd/export/upstart.rs
+++ b/src/cmd/export/upstart.rs
@@ -12,20 +12,7 @@ use std::path::PathBuf;
 
 pub struct Exporter {
     pub procfile: Procfile,
-    // ExportOpts
-    pub format: String,
-    pub location: PathBuf,
-    pub app: Option<String>,
-    pub formation: String,
-    pub log_path: Option<PathBuf>,
-    pub run_path: Option<PathBuf>,
-    pub port: Option<String>,
-    pub template_path: Option<PathBuf>,
-    pub user: Option<String>,
-    pub env_path: PathBuf,
-    pub procfile_path: PathBuf,
-    pub root_path: Option<PathBuf>,
-    pub timeout: String,
+    pub opts: ExportOpts,
 }
 
 #[derive(Serialize)]
@@ -94,7 +81,7 @@ impl Exporter {
         let p = ProcessParams {
             app: self.app(),
             name: app_name.to_string(),
-            port: port_for(self.opts().env_path, self.opts().port, index, con_index + 1),
+            port: port_for(self.opts.env_path.clone(), self.opts.port.clone(), index, con_index + 1),
             env_without_port: self.env_without_port(),
             setuid: self.username(),
             chdir: self.root_path().into_os_string().into_string().unwrap(),
@@ -111,19 +98,21 @@ impl Default for Exporter {
             procfile: Procfile {
                 data: HashMap::new(),
             },
-            format: String::from(""),
-            location: PathBuf::from("location"),
-            app: None,
-            formation: String::from("all=1"),
-            log_path: None,
-            run_path: None,
-            port: None,
-            template_path: None,
-            user: None,
-            env_path: PathBuf::from(".env"),
-            procfile_path: PathBuf::from("Procfile"),
-            root_path: Some(env::current_dir().unwrap()),
-            timeout: String::from("5"),
+            opts: ExportOpts {
+                format: String::from(""),
+                location: PathBuf::from("location"),
+                app: None,
+                formation: String::from("all=1"),
+                log_path: None,
+                run_path: None,
+                port: None,
+                template_path: None,
+                user: None,
+                env_path: PathBuf::from(".env"),
+                procfile_path: PathBuf::from("Procfile"),
+                root_path: Some(env::current_dir().unwrap()),
+                timeout: String::from("5"),
+            }
         }
     }
 }
@@ -162,20 +151,6 @@ impl Exportable for Exporter {
     }
 
     fn opts(&self) -> ExportOpts {
-        ExportOpts {
-            format: self.format.clone(),
-            location: self.location.clone(),
-            app: self.app.clone(),
-            formation: self.formation.clone(),
-            log_path: self.log_path.clone(),
-            run_path: self.run_path.clone(),
-            port: self.port.clone(),
-            template_path: self.template_path.clone(),
-            user: self.user.clone(),
-            env_path: self.env_path.clone(),
-            procfile_path: self.procfile_path.clone(),
-            root_path: self.root_path.clone(),
-            timeout: self.timeout.clone(),
-        }
+        self.opts.clone()
     }
 }

--- a/src/cmd/export/upstart.rs
+++ b/src/cmd/export/upstart.rs
@@ -150,7 +150,7 @@ impl Exportable for Exporter {
         Ok(())
     }
 
-    fn opts(&self) -> ExportOpts {
-        self.opts.clone()
+    fn ref_opts(&self) -> &ExportOpts {
+        &self.opts
     }
 }

--- a/src/cmd/export/upstart.rs
+++ b/src/cmd/export/upstart.rs
@@ -81,7 +81,12 @@ impl Exporter {
         let p = ProcessParams {
             app: self.app(),
             name: app_name.to_string(),
-            port: port_for(self.opts.env_path.clone(), self.opts.port.clone(), index, con_index + 1),
+            port: port_for(
+                self.opts.env_path.clone(),
+                self.opts.port.clone(),
+                index,
+                con_index + 1,
+            ),
             env_without_port: self.env_without_port(),
             setuid: self.username(),
             chdir: self.root_path().into_os_string().into_string().unwrap(),
@@ -112,7 +117,7 @@ impl Default for Exporter {
                 procfile_path: PathBuf::from("Procfile"),
                 root_path: Some(env::current_dir().unwrap()),
                 timeout: String::from("5"),
-            }
+            },
         }
     }
 }
@@ -128,7 +133,7 @@ impl Exportable for Exporter {
         let output_path = self.output_path(master_file);
 
         clean_paths.push(output_path.clone());
-        tmpl_data.push(Template{
+        tmpl_data.push(Template {
             template_path: self.master_tmpl_path(),
             data: Map::new(),
             output_path,
@@ -142,7 +147,7 @@ impl Exportable for Exporter {
             let output_path = self.output_path(process_master_file);
 
             clean_paths.push(output_path.clone());
-            tmpl_data.push(Template{
+            tmpl_data.push(Template {
                 template_path: self.process_master_tmpl_path(),
                 data: self.make_process_master_data(),
                 output_path,
@@ -153,7 +158,7 @@ impl Exportable for Exporter {
                 let output_path = self.output_path(process_file);
 
                 clean_paths.push(output_path.clone());
-                tmpl_data.push(Template{
+                tmpl_data.push(Template {
                     template_path: self.process_tmpl_path(),
                     data: self.make_process_data(pe, &name, index, n),
                     output_path,

--- a/src/cmd/start.rs
+++ b/src/cmd/start.rs
@@ -127,15 +127,14 @@ pub fn run(opts: StartOpts) -> Result<(), Box<dyn std::error::Error>> {
 
     // use handle_signal
     let procs2 = Arc::clone(&procs);
-    let check_for_child_termination_thread = process::build_check_for_child_termination_thread(procs2, display_opts);
+    let check_for_child_termination_thread = process::build_check_for_child_termination_thread(procs2, display_opts.clone());
     proc_handles.push(check_for_child_termination_thread);
 
     let procs = Arc::clone(&procs);
     proc_handles.push(signal::handle_signal_thread(
         procs,
-        padding,
         opts.timeout.parse::<u64>().unwrap(),
-        is_timestamp,
+        display_opts,
     ));
 
     for handle in proc_handles {

--- a/src/cmd/start.rs
+++ b/src/cmd/start.rs
@@ -1,7 +1,8 @@
 use crate::output;
-use crate::process::{self, Process, ProcessOpts};
+use crate::process::{self, Process};
 use crate::procfile::read_procfile;
 use crate::signal;
+use crate::opt::DisplayOpts;
 
 use std::path::PathBuf;
 use std::sync::{Arc, Barrier, Mutex};
@@ -71,7 +72,7 @@ pub fn run(opts: StartOpts) -> Result<(), Box<dyn std::error::Error>> {
     let barrier = Arc::new(Barrier::new(process_len + 1));
     let mut total = 0;
     let is_timestamp = !opts.is_no_timestamp;
-    let process_opts = ProcessOpts { padding, is_timestamp };
+    let display_opts = DisplayOpts { padding, is_timestamp };
 
     for (name, pe) in procfile.data.iter() {
         let con = pe.concurrency.get();
@@ -87,7 +88,7 @@ pub fn run(opts: StartOpts) -> Result<(), Box<dyn std::error::Error>> {
             let cmd = pe.command.clone();
             let env_path = opts.env_path.clone();
             let port = opts.port.clone();
-            let opts = process_opts.clone();
+            let opts = display_opts.clone();
 
             let exec_and_output_thread = process::build_exec_and_output_thread(move || {
                 let proc = Process::new(
@@ -126,7 +127,7 @@ pub fn run(opts: StartOpts) -> Result<(), Box<dyn std::error::Error>> {
 
     // use handle_signal
     let procs2 = Arc::clone(&procs);
-    let check_for_child_termination_thread = process::build_check_for_child_termination_thread(procs2, process_opts);
+    let check_for_child_termination_thread = process::build_check_for_child_termination_thread(procs2, display_opts);
     proc_handles.push(check_for_child_termination_thread);
 
     let procs = Arc::clone(&procs);

--- a/src/cmd/start.rs
+++ b/src/cmd/start.rs
@@ -1,5 +1,5 @@
 use crate::output;
-use crate::process;
+use crate::process::{self, Process, ProcessOpts};
 use crate::procfile::read_procfile;
 use crate::signal;
 
@@ -69,28 +69,57 @@ pub fn run(opts: StartOpts) -> Result<(), Box<dyn std::error::Error>> {
     let padding = procfile.padding();
 
     let barrier = Arc::new(Barrier::new(process_len + 1));
-    let mut index = 0;
+    let mut total = 0;
     let is_timestamp = !opts.is_no_timestamp;
 
     for (name, pe) in procfile.data.iter() {
         let con = pe.concurrency.get();
+        let index = total;
         let output = Arc::new(output::Output::new(index, padding, is_timestamp));
-        let before_index = index;
-        index += 1;
+        total += 1;
 
         for n in 0..con {
             let barrier = barrier.clone();
             let procs = procs.clone();
             let output = output.clone();
-            let name = name.clone();
-            let pe_command = pe.command.clone();
+            let process_name = name.clone();
+            let cmd = pe.command.clone();
             let env_path = opts.env_path.clone();
             let port = opts.port.clone();
 
-            let each_fn = process::each_handle_exec_and_output(procs, padding, barrier, output);
-            let each_handle_exec_and_output =
-                each_fn(name, n, pe_command, env_path, port, before_index);
-            proc_handles.push(each_handle_exec_and_output);
+            let exec_and_output_thread = process::build_exec_and_output_thread(move || {
+                let proc = Process::new(
+                    process_name,
+                    cmd,
+                    env_path,
+                    port,
+                    n,
+                    index,
+                    Some(ProcessOpts {
+                        padding,
+                        is_timestamp,
+                    }),
+                );
+                let proc2 = Arc::new(Mutex::new(proc));
+                let proc3 = Arc::clone(&proc2);
+                let child_id = proc2.lock().unwrap().child.id() as i32;
+
+                output.log.output(
+                    "system",
+                    &format!(
+                        "{0:1$} start at pid: {2}",
+                        &proc2.lock().unwrap().name,
+                        padding,
+                        &child_id
+                    ),
+                );
+
+                procs.lock().unwrap().push(proc2);
+                barrier.wait();
+
+                output.handle_output(&proc3);
+            });
+            proc_handles.push(exec_and_output_thread);
         }
     }
 

--- a/src/cmd/start.rs
+++ b/src/cmd/start.rs
@@ -77,7 +77,7 @@ pub fn run(opts: StartOpts) -> Result<(), Box<dyn std::error::Error>> {
     for (name, pe) in procfile.data.iter() {
         let con = pe.concurrency.get();
         let index = total;
-        let output = Arc::new(output::Output::new(index, padding, is_timestamp));
+        let output = Arc::new(output::Output::new(index, display_opts.clone()));
         total += 1;
 
         for n in 0..con {

--- a/src/log/color.rs
+++ b/src/log/color.rs
@@ -1,5 +1,5 @@
-use crate::opt::DisplayOpts;
 use crate::log::{now, Printable};
+use crate::opt::DisplayOpts;
 use colored::*;
 
 const COLORS: [&str; 12] = [

--- a/src/log/color.rs
+++ b/src/log/color.rs
@@ -1,3 +1,4 @@
+use crate::opt::DisplayOpts;
 use crate::log::{now, Printable};
 use colored::*;
 
@@ -19,8 +20,7 @@ const COLORS: [&str; 12] = [
 #[derive(Default)]
 pub struct Log {
     pub index: usize,
-    pub padding: usize,
-    pub is_timestamp: bool,
+    pub opts: DisplayOpts,
 }
 
 unsafe impl Sync for Log {}
@@ -41,11 +41,11 @@ impl Printable for Log {
     fn output(&self, proc_name: &str, content: &str) {
         let color = COLORS[self.index % COLORS.len()];
 
-        if self.is_timestamp {
+        if self.opts.is_timestamp {
             println!(
                 "{3} {0:1$} | {2}",
                 proc_name.color(color),
-                self.padding,
+                self.opts.padding,
                 content.color(color),
                 now().color(color)
             )
@@ -53,7 +53,7 @@ impl Printable for Log {
             println!(
                 "{0:1$} | {2}",
                 proc_name.color(color),
-                self.padding,
+                self.opts.padding,
                 content.color(color),
             )
         }

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -47,15 +47,10 @@ pub fn output(proc_name: &str, content: &str, index: Option<usize>, opt: &LogOpt
     log.output(proc_name, content)
 }
 
-pub fn error(proc_name: &str, err: &dyn std::error::Error, padding: Option<usize>, opt: &LogOpt) {
+pub fn error(proc_name: &str, err: &dyn std::error::Error, is_padding: bool, opt: &LogOpt) {
     let content = &format!("error: {:?}", err);
-    if let Some(p) = padding {
-        let remake_opt = LogOpt {
-            is_color: opt.is_color,
-            padding: p,
-            is_timestamp: opt.is_timestamp,
-        };
-        output(proc_name, content, None, &remake_opt);
+    if is_padding {
+        output(proc_name, content, None, &opt);
     } else {
         let remake_opt = LogOpt {
             is_color: opt.is_color,

--- a/src/log/plain.rs
+++ b/src/log/plain.rs
@@ -1,5 +1,5 @@
-use crate::opt::DisplayOpts;
 use crate::log::{now, Printable};
+use crate::opt::DisplayOpts;
 
 #[derive(Default)]
 pub struct Log {
@@ -24,7 +24,13 @@ impl Log {
 impl Printable for Log {
     fn output(&self, proc_name: &str, content: &str) {
         if self.opts.is_timestamp {
-            println!("{3} {0:1$} | {2}", proc_name, self.opts.padding, content, now())
+            println!(
+                "{3} {0:1$} | {2}",
+                proc_name,
+                self.opts.padding,
+                content,
+                now()
+            )
         } else {
             println!("{0:1$} | {2}", proc_name, self.opts.padding, content)
         }

--- a/src/log/plain.rs
+++ b/src/log/plain.rs
@@ -1,10 +1,10 @@
+use crate::opt::DisplayOpts;
 use crate::log::{now, Printable};
 
 #[derive(Default)]
 pub struct Log {
     pub index: usize,
-    pub padding: usize,
-    pub is_timestamp: bool,
+    pub opts: DisplayOpts,
 }
 
 unsafe impl Sync for Log {}
@@ -23,10 +23,10 @@ impl Log {
 
 impl Printable for Log {
     fn output(&self, proc_name: &str, content: &str) {
-        if self.is_timestamp {
-            println!("{3} {0:1$} | {2}", proc_name, self.padding, content, now())
+        if self.opts.is_timestamp {
+            println!("{3} {0:1$} | {2}", proc_name, self.opts.padding, content, now())
         } else {
-            println!("{0:1$} | {2}", proc_name, self.padding, content)
+            println!("{0:1$} | {2}", proc_name, self.opts.padding, content)
         }
     }
 

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -40,3 +40,12 @@ pub struct DisplayOpts {
     pub padding: usize,
     pub is_timestamp: bool,
 }
+
+impl Default for DisplayOpts {
+    fn default()-> Self {
+        DisplayOpts {
+            padding: 0,
+            is_timestamp: true
+        }
+    }
+}

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -42,10 +42,10 @@ pub struct DisplayOpts {
 }
 
 impl Default for DisplayOpts {
-    fn default()-> Self {
+    fn default() -> Self {
         DisplayOpts {
             padding: 0,
-            is_timestamp: true
+            is_timestamp: true,
         }
     }
 }

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -32,3 +32,11 @@ pub enum Ultraman {
     )]
     Export(ExportOpts),
 }
+
+///// Options not related to commands /////
+
+#[derive(Clone)]
+pub struct DisplayOpts {
+    pub padding: usize,
+    pub is_timestamp: bool,
+}

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,7 +1,7 @@
 use crate::log::{Log, LogOpt, Printable};
+use crate::opt::DisplayOpts;
 use crate::process::Process;
 use crate::stream_read::{PipeError, PipeStreamReader, PipedLine};
-use crate::opt::DisplayOpts;
 
 use crossbeam_channel::Select;
 use std::sync::{Arc, Mutex};
@@ -121,7 +121,13 @@ mod tests {
         }));
 
         let proc2 = Arc::clone(&proc);
-        let output = Output::new(0, DisplayOpts { padding: 10, is_timestamp: true });
+        let output = Output::new(
+            0,
+            DisplayOpts {
+                padding: 10,
+                is_timestamp: true,
+            },
+        );
         output.handle_output(&proc2);
 
         Ok(())

--- a/src/output.rs
+++ b/src/output.rs
@@ -115,6 +115,7 @@ mod tests {
                 .stderr(Stdio::piped())
                 .spawn()
                 .expect("failed execute handle_output command"),
+            opts: None,
         }));
 
         let proc2 = Arc::clone(&proc);

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,6 +1,8 @@
 use crate::log::{Log, LogOpt, Printable};
 use crate::process::Process;
 use crate::stream_read::{PipeError, PipeStreamReader, PipedLine};
+use crate::opt::DisplayOpts;
+
 use crossbeam_channel::Select;
 use std::sync::{Arc, Mutex};
 
@@ -9,14 +11,14 @@ pub struct Output {
 }
 
 impl Output {
-    pub fn new(index: usize, padding: usize, is_timestamp: bool) -> Self {
+    pub fn new(index: usize, opts: DisplayOpts) -> Self {
         Output {
             log: Log::new(
                 index,
-                padding,
                 &LogOpt {
                     is_color: true,
-                    is_timestamp,
+                    padding: opts.padding,
+                    is_timestamp: opts.is_timestamp,
                 },
             ),
         }
@@ -119,7 +121,7 @@ mod tests {
         }));
 
         let proc2 = Arc::clone(&proc);
-        let output = Output::new(0, 10, true);
+        let output = Output::new(0, DisplayOpts { padding: 10, is_timestamp: true });
         output.handle_output(&proc2);
 
         Ok(())

--- a/src/process.rs
+++ b/src/process.rs
@@ -82,9 +82,9 @@ pub fn build_check_for_child_termination_thread(
                 // Waiting for the end of any one child process
                 let procs2 = Arc::clone(&procs);
                 let procs3 = Arc::clone(&procs);
-                if let Some((_, code)) = check_for_child_termination(procs2, opts.padding, opts.is_timestamp)
+                if let Some((_, code)) = check_for_child_termination(procs2, opts.clone())
                 {
-                    signal::kill_children(procs3, opts.padding, Signal::SIGTERM, code, opts.is_timestamp)
+                    signal::kill_children(procs3, Signal::SIGTERM, code, opts.clone())
                 }
             }
         })
@@ -93,8 +93,7 @@ pub fn build_check_for_child_termination_thread(
 
 pub fn check_for_child_termination(
     procs: Arc<Mutex<Vec<Arc<Mutex<Process>>>>>,
-    padding: usize,
-    is_timestamp: bool,
+    opts: DisplayOpts,
 ) -> Option<(Pid, i32)> {
     let child_termination_fn = Box::new(move |pid: Pid, message: &str| {
         procs.lock().unwrap().retain(|p| {
@@ -106,11 +105,11 @@ pub fn check_for_child_termination(
                 log::output(
                         &proc_name,
                         &message,
-                        padding,
+                        opts.padding,
                         Some(proc_index),
                         &LogOpt {
                             is_color: true,
-                            is_timestamp,
+                            is_timestamp: opts.is_timestamp,
                         },
                     );
             }

--- a/src/process.rs
+++ b/src/process.rs
@@ -105,10 +105,10 @@ pub fn check_for_child_termination(
                 log::output(
                         &proc_name,
                         &message,
-                        opts.padding,
                         Some(proc_index),
                         &LogOpt {
                             is_color: true,
+                            padding: opts.padding,
                             is_timestamp: opts.is_timestamp,
                         },
                     );

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,6 +1,7 @@
 use crate::env::read_env;
 use crate::log::{self, LogOpt};
 use crate::signal;
+use crate::opt::DisplayOpts;
 use nix::sys::signal::Signal;
 use nix::sys::wait::WaitStatus;
 use nix::{self, unistd::Pid};
@@ -13,17 +14,11 @@ use std::thread::{self, JoinHandle};
 #[cfg(not(test))]
 use std::process::exit;
 
-#[derive(Clone)]
-pub struct ProcessOpts {
-    pub padding: usize,
-    pub is_timestamp: bool,
-}
-
 pub struct Process {
     pub index: usize,
     pub name: String,
     pub child: Child,
-    pub opts: Option<ProcessOpts>,
+    pub opts: Option<DisplayOpts>,
 }
 
 impl Process {
@@ -34,7 +29,7 @@ impl Process {
         port: Option<String>,
         concurrency_index: usize,
         index: usize,
-        opts: Option<ProcessOpts>,
+        opts: Option<DisplayOpts>,
     ) -> Self {
         let mut read_env = read_env(env_path.clone()).expect("failed read .env");
         read_env.insert(
@@ -78,7 +73,7 @@ where
 
 pub fn build_check_for_child_termination_thread(
     procs: Arc<Mutex<Vec<Arc<Mutex<Process>>>>>,
-    opts: ProcessOpts,
+    opts: DisplayOpts,
 ) -> JoinHandle<()> {
     thread::Builder::new()
         .name(String::from(format!("check child terminated")))
@@ -210,7 +205,7 @@ mod tests {
         let procs2 = Arc::clone(&procs);
         let padding = 10;
 
-        build_check_for_child_termination_thread(procs2, ProcessOpts { padding, is_timestamp: true })
+        build_check_for_child_termination_thread(procs2, DisplayOpts { padding, is_timestamp: true })
             .join()
             .expect("exit 0");
     }

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,7 +1,7 @@
 use crate::env::read_env;
 use crate::log::{self, LogOpt};
-use crate::signal;
 use crate::opt::DisplayOpts;
+use crate::signal;
 use nix::sys::signal::Signal;
 use nix::sys::wait::WaitStatus;
 use nix::{self, unistd::Pid};
@@ -82,8 +82,7 @@ pub fn build_check_for_child_termination_thread(
                 // Waiting for the end of any one child process
                 let procs2 = Arc::clone(&procs);
                 let procs3 = Arc::clone(&procs);
-                if let Some((_, code)) = check_for_child_termination(procs2, opts.clone())
-                {
+                if let Some((_, code)) = check_for_child_termination(procs2, opts.clone()) {
                     signal::kill_children(procs3, Signal::SIGTERM, code, opts.clone())
                 }
             }
@@ -103,15 +102,15 @@ pub fn check_for_child_termination(
                 let proc_name = &proc.name;
                 let proc_index = proc.index;
                 log::output(
-                        &proc_name,
-                        &message,
-                        Some(proc_index),
-                        &LogOpt {
-                            is_color: true,
-                            padding: opts.padding,
-                            is_timestamp: opts.is_timestamp,
-                        },
-                    );
+                    &proc_name,
+                    &message,
+                    Some(proc_index),
+                    &LogOpt {
+                        is_color: true,
+                        padding: opts.padding,
+                        is_timestamp: opts.is_timestamp,
+                    },
+                );
             }
             Pid::from_raw(child_id) != pid
         });
@@ -204,8 +203,14 @@ mod tests {
         let procs2 = Arc::clone(&procs);
         let padding = 10;
 
-        build_check_for_child_termination_thread(procs2, DisplayOpts { padding, is_timestamp: true })
-            .join()
-            .expect("exit 0");
+        build_check_for_child_termination_thread(
+            procs2,
+            DisplayOpts {
+                padding,
+                is_timestamp: true,
+            },
+        )
+        .join()
+        .expect("exit 0");
     }
 }

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -42,10 +42,10 @@ fn trap_signal_at_multithred(
                 log::output(
                     "system",
                     "SIGINT received, starting shutdown",
-                    opts.padding - 2,
                     None,
                     &LogOpt {
                         is_color: false,
+                        padding: opts.padding - 2,
                         is_timestamp: opts.is_timestamp,
                     },
                 );
@@ -53,10 +53,10 @@ fn trap_signal_at_multithred(
                 log::output(
                     "system",
                     "sending SIGTERM to all processes",
-                    opts.padding,
                     None,
                     &LogOpt {
                         is_color: false,
+                        padding: opts.padding,
                         is_timestamp: opts.is_timestamp,
                     },
                 );
@@ -66,10 +66,10 @@ fn trap_signal_at_multithred(
                 log::output(
                     "system",
                     "exit 0",
-                    opts.padding,
                     None,
                     &LogOpt {
                         is_color: false,
+                        padding: opts.padding,
                         is_timestamp: opts.is_timestamp,
                     },
                 );
@@ -113,10 +113,10 @@ pub fn terminate_gracefully(
     log::output(
         "system",
         "sending SIGKILL to all processes",
-        opts.padding,
         None,
         &LogOpt {
             is_color: false,
+            padding: opts.padding,
             is_timestamp: opts.is_timestamp,
         },
     );
@@ -143,10 +143,10 @@ pub fn kill_children(
                 &child.id(),
                 Signal::as_str(signal),
             ),
-            opts.padding,
             None,
             &LogOpt {
                 is_color: false,
+                padding: opts.padding,
                 is_timestamp: opts.is_timestamp,
             },
         );
@@ -158,16 +158,17 @@ pub fn kill_children(
                 Some(opts.padding),
                 &LogOpt {
                     is_color: false,
+                    padding: opts.padding,
                     is_timestamp: opts.is_timestamp,
                 },
             );
             log::output(
                 "system",
                 &format!("exit {}", _code),
-                opts.padding,
                 None,
                 &LogOpt {
                     is_color: false,
+                    padding: opts.padding,
                     is_timestamp: opts.is_timestamp,
                 },
             );

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -207,6 +207,7 @@ mod tests {
                     .arg("trap_signal_at_multithred_1")
                     .spawn()
                     .expect("failed execute test-app-1"),
+                opts: None,
             })),
             Arc::new(Mutex::new(Process {
                 index: 1,
@@ -215,6 +216,7 @@ mod tests {
                     .arg("trap_signal_at_multithred_2")
                     .spawn()
                     .expect("failed execute test-app-2"),
+                opts: None,
             })),
         ]));
 

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,6 +1,6 @@
 use crate::log::{self, LogOpt};
-use crate::process::{self, Process};
 use crate::opt::DisplayOpts;
+use crate::process::{self, Process};
 
 use nix::sys::signal::{self, Signal};
 use nix::unistd::Pid;
@@ -20,8 +20,7 @@ pub fn handle_signal_thread(
     let result = thread::Builder::new()
         .name(String::from("handling signal"))
         .spawn(move || {
-            trap_signal_at_multithred(procs, timeout, opts)
-                .expect("failed trap signals")
+            trap_signal_at_multithred(procs, timeout, opts).expect("failed trap signals")
         })
         .expect("failed handle signals");
 
@@ -222,8 +221,15 @@ mod tests {
 
         let procs2 = Arc::clone(&procs);
         let thread_trap_signal = thread::spawn(move || {
-            trap_signal_at_multithred(procs2, 5, DisplayOpts { padding: 10, is_timestamp: true })
-                .expect("failed trap_signal_at_multithred")
+            trap_signal_at_multithred(
+                procs2,
+                5,
+                DisplayOpts {
+                    padding: 10,
+                    is_timestamp: true,
+                },
+            )
+            .expect("failed trap_signal_at_multithred")
         });
 
         let thread_send_sigint = thread::spawn(move || {

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -155,7 +155,7 @@ pub fn kill_children(
             log::error(
                 "system",
                 &e,
-                Some(opts.padding),
+                true,
                 &LogOpt {
                     is_color: false,
                     padding: opts.padding,


### PR DESCRIPTION
### Summary

Resolve #6

- Use DisplayOpts
- Separated cleaning and writing processes as much as possible

### Work

Separated cleaning and writing processes as much as possible

```bash
$ cargo run export daemon ./tmp/daemon -d /home/app -u root
warning: use of deprecated function `dotenv::from_path_iter`: please use `from_path` in conjunction with `var` instead
  --> src/env.rs:10:25
   |
10 |     if let Some(iter) = dotenv::from_path_iter(filepath.as_path()).ok() {
   |                         ^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: 1 warning emitted

    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
     Running `target/debug/ultraman export daemon ./tmp/daemon -d /home/app -u root`
[ultraman export] cleaning: ./tmp/daemon/app.conf
[ultraman export] cleaning: ./tmp/daemon/app-exit_0.conf
[ultraman export] cleaning: ./tmp/daemon/app-exit_0-1.conf
[ultraman export] cleaning: ./tmp/daemon/app-exit_1.conf
[ultraman export] cleaning: ./tmp/daemon/app-exit_1-1.conf
[ultraman export] cleaning: ./tmp/daemon/app-loop.conf
[ultraman export] cleaning: ./tmp/daemon/app-loop-1.conf
[ultraman export] writing: ./tmp/daemon/app.conf
[ultraman export] writing: ./tmp/daemon/app-exit_0.conf
[ultraman export] writing: ./tmp/daemon/app-exit_0-1.conf
[ultraman export] writing: ./tmp/daemon/app-exit_1.conf
[ultraman export] writing: ./tmp/daemon/app-exit_1-1.conf
[ultraman export] writing: ./tmp/daemon/app-loop.conf
[ultraman export] writing: ./tmp/daemon/app-loop-1.conf
```

### Test

```bash
$ make test
cargo test --locked
   Compiling ultraman v0.1.1 (/Users/yukihirop/RustProjects/ultraman)
warning: use of deprecated function `dotenv::from_path_iter`: please use `from_path` in conjunction with `var` instead
  --> src/env.rs:10:25
   |
10 |     if let Some(iter) = dotenv::from_path_iter(filepath.as_path()).ok() {
   |                         ^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: 1 warning emitted

    Finished test [unoptimized + debuginfo] target(s) in 3.59s
     Running target/debug/deps/ultraman-54a1f582d38778d3

running 15 tests
test procfile::tests::test_padding ... ok
test procfile::tests::test_find_by ... ok
test procfile::tests::test_process_len ... ok
test log::tests::test_output_when_not_coloring ... ok
test procfile::tests::test_set_concurrency_all ... ok
test procfile::tests::test_set_concurrency ... ok
test signal::tests::test_trap_signal_at_multithred ... ignored
test procfile::tests::test_set_concurrency_when_panic ... ok
test log::tests::test_error ... ok
test log::tests::test_output_when_coloring ... ok
test env::tests::test_read_env ... ok
test procfile::tests::test_parse_procfile ... ok
test stream_read::tests::test_new ... ok
20:56:24 system     | sending SIGTERM for check_for_child_termination_thread-1 at pid 73699
20:56:24 system     | sending SIGTERM for check_for_child_termination_thread-2 at pid 73700
20:56:24 check_for_child_termination_thread-2 | terminated by SIGTERM
20:56:24 check_for_child_termination_thread-1 | terminated by SIGTERM
thread 'check child terminated' panicked at 'exit 0', src/process.rs:141:17
test output::tests::test_handle_output ... ok
test process::tests::test_build_check_for_child_termination_thread ... ok

test result: ok. 14 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out

cargo test --locked -- --ignored
warning: use of deprecated function `dotenv::from_path_iter`: please use `from_path` in conjunction with `var` instead
  --> src/env.rs:10:25
   |
10 |     if let Some(iter) = dotenv::from_path_iter(filepath.as_path()).ok() {
   |                         ^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: 1 warning emitted

    Finished test [unoptimized + debuginfo] target(s) in 0.06s
     Running target/debug/deps/ultraman-54a1f582d38778d3

running 1 test
trap_signal_at_multithred_2
trap_signal_at_multithred_1
trap_signal_at_multithred_2
trap_signal_at_multithred_1
trap_signal_at_multithred_1
trap_signal_at_multithred_2
trap_signal_at_multithred_2
trap_signal_at_multithred_1
20:56:32 system   | SIGINT received, starting shutdown
20:56:32 system     | sending SIGTERM to all processes
20:56:32 system     | sending SIGTERM for trap_signal_at_multithred-1 at pid 73716
20:56:32 system     | sending SIGTERM for trap_signal_at_multithred-2 at pid 73717
20:56:32 trap_signal_at_multithred-2 | terminated by SIGTERM
20:56:32 trap_signal_at_multithred-1 | terminated by SIGTERM
20:56:32 system     | exit 0
test signal::tests::test_trap_signal_at_multithred ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 14 filtered out
```