### PR TITLE
The base port value is incorrect 

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -7,9 +7,10 @@ pub type Env = HashMap<String, String>;
 pub fn read_env(filepath: PathBuf) -> Result<Env, Box<dyn std::error::Error>> {
     let mut env: Env = HashMap::new();
 
-    if let Some(iter) = dotenv::from_path_iter(filepath.as_path()).ok() {
-        for item in iter {
-            let (key, val) = item.expect("Could not convert .env to tuple");
+    if let Some(()) = dotenv::from_path(filepath.as_path()).ok() {
+        let env_vars: Vec<(String, String)> = dotenv::vars().collect();
+        for pair in env_vars {
+            let (key, val) = pair;
             env.insert(key, val);
         }
         return Ok(env);
@@ -42,7 +43,8 @@ PS=1
 
         assert_eq!(result.get("PORT").unwrap(), "5000");
         assert_eq!(result.get("PS").unwrap(), "1");
-        assert_eq!(result.get("CARGO_PKG_VERSION"), None);
+        assert_eq!(result.get("CARGO_PKG_VERSION").unwrap(), "0.1.2");
+        assert_eq!(result.get("DO_NOT_EXIST_ENV"), None);
 
         Ok(())
     }

--- a/src/process.rs
+++ b/src/process.rs
@@ -27,24 +27,24 @@ impl Process {
         cmd: String,
         env_path: PathBuf,
         port: Option<String>,
-        concurrency_index: usize,
+        instance_index: usize,
         index: usize,
         opts: Option<DisplayOpts>,
     ) -> Self {
         let mut read_env = read_env(env_path.clone()).expect("failed read .env");
         read_env.insert(
             String::from("PORT"),
-            port_for(env_path, port, index, concurrency_index),
+            port_for(env_path, port, index, instance_index),
         );
         read_env.insert(
             String::from("PS"),
-            ps_for(process_name.clone(), concurrency_index + 1),
+            ps_for(process_name.clone(), instance_index + 1),
         );
         let shell = os_env::var("SHELL").expect("$SHELL is not set");
 
         Process {
             index,
-            name: ps_for(process_name, concurrency_index + 1),
+            name: ps_for(process_name, instance_index + 1),
             child: Command::new(shell)
                 .arg("-c")
                 .arg(cmd)
@@ -148,18 +148,18 @@ pub fn check_for_child_termination(
     };
 }
 
-fn ps_for(process_name: String, concurrency: usize) -> String {
-    format!("{}.{}", process_name, concurrency)
+fn ps_for(process_name: String, instance_index: usize) -> String {
+    format!("{}.{}", process_name, instance_index)
 }
 
 pub fn port_for(
     env_path: PathBuf,
     port: Option<String>,
     index: usize,
-    concurrency: usize,
+    instance_index: usize,
 ) -> String {
     let result =
-        base_port(env_path, port).parse::<usize>().unwrap() + index * 100 + concurrency;
+        base_port(env_path, port).parse::<usize>().unwrap() + index * 100 + instance_index;
     result.to_string()
 }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -159,7 +159,7 @@ pub fn port_for(
     concurrency: usize,
 ) -> String {
     let result =
-        base_port(env_path, port).parse::<usize>().unwrap() + index * 100 + concurrency - 1;
+        base_port(env_path, port).parse::<usize>().unwrap() + index * 100 + concurrency;
     result.to_string()
 }
 


### PR DESCRIPTION
### Summary

Resolve #36

### Other Information

N/A

### Work

```
(⎈ |minikube:default)#2022-03-26 14:30|yukihirop@FukudanoMacBook-Pro-2:~/RustProjects/ultraman (issues36/fix_port)
$ cargo run start
WARN rustc_metadata::locator no metadata found: failed to decompress metadata: /Users/yukihirop/RustProjects/ultraman/target/debug/deps/libproc_macro_error_attr-a9c8a9c7d06f0334.dylib
WARN rustc_metadata::locator no metadata found: failed to decompress metadata: /Users/yukihirop/RustProjects/ultraman/target/debug/deps/libconst_fn-8af6ecc2b940a780.dylib
   Compiling ultraman v0.1.2 (/Users/yukihirop/RustProjects/ultraman)
WARN rustc_metadata::locator no metadata found: failed to decompress metadata: /Users/yukihirop/RustProjects/ultraman/target/debug/deps/libstructopt_derive-91aeda76a19b601d.dylib
WARN rustc_metadata::locator no metadata found: failed to decompress metadata: /Users/yukihirop/RustProjects/ultraman/target/debug/deps/libstructopt_derive-7695d8bd7992ed19.dylib
WARN rustc_metadata::locator no metadata found: failed to decompress metadata: /Users/yukihirop/RustProjects/ultraman/target/debug/deps/libpest_derive-c3453fa0646f45e9.dylib
WARN rustc_metadata::locator no metadata found: failed to decompress metadata: /Users/yukihirop/RustProjects/ultraman/target/debug/deps/libpest_derive-81003b802451323e.dylib
WARN rustc_metadata::locator no metadata found: failed to decompress metadata: /Users/yukihirop/RustProjects/ultraman/target/debug/deps/libconst_fn-8af6ecc2b940a780.dylib
    Finished dev [unoptimized + debuginfo] target(s) in 3.12s
     Running `target/debug/ultraman start`
14:30:56 system    | loop.1    start at pid: 21680
14:30:56 system    | exit_0.1  start at pid: 21682
14:30:56 system    | exit_1.1  start at pid: 21681
14:30:57 loop.1    | 6000
14:30:58 exit_1.1  | failed
14:30:58 loop.1    | 6000
14:30:58 exit_1.1  | exited with code 1
14:30:58 system    | sending SIGTERM for loop.1    at pid 21680
14:30:58 system    | sending SIGTERM for exit_0.1  at pid 21682
14:30:58 exit_0.1  | terminated by SIGTERM
14:30:58 loop.1    | terminated by SIGTERM
```

### Test

```
(⎈ |minikube:default)#2022-03-26 14:30|yukihirop@FukudanoMacBook-Pro-2:~/RustProjects/ultraman (issues36/fix_port)
$ cargo test
WARN rustc_metadata::locator no metadata found: failed to decompress metadata: /Users/yukihirop/RustProjects/ultraman/target/debug/deps/libproc_macro_error_attr-a9c8a9c7d06f0334.dylib
WARN rustc_metadata::locator no metadata found: failed to decompress metadata: /Users/yukihirop/RustProjects/ultraman/target/debug/deps/libconst_fn-8af6ecc2b940a780.dylib
WARN rustc_metadata::locator no metadata found: failed to decompress metadata: /Users/yukihirop/RustProjects/ultraman/target/debug/deps/libstructopt_derive-91aeda76a19b601d.dylib
WARN rustc_metadata::locator no metadata found: failed to decompress metadata: /Users/yukihirop/RustProjects/ultraman/target/debug/deps/libstructopt_derive-7695d8bd7992ed19.dylib
WARN rustc_metadata::locator no metadata found: failed to decompress metadata: /Users/yukihirop/RustProjects/ultraman/target/debug/deps/libpest_derive-c3453fa0646f45e9.dylib
WARN rustc_metadata::locator no metadata found: failed to decompress metadata: /Users/yukihirop/RustProjects/ultraman/target/debug/deps/libpest_derive-81003b802451323e.dylib
WARN rustc_metadata::locator no metadata found: failed to decompress metadata: /Users/yukihirop/RustProjects/ultraman/target/debug/deps/libconst_fn-8af6ecc2b940a780.dylib
    Finished test [unoptimized + debuginfo] target(s) in 0.17s
     Running unittests (target/debug/deps/ultraman-bb3643b00a0b9296)

running 15 tests
test procfile::tests::test_padding ... ok
test procfile::tests::test_find_by ... ok
test procfile::tests::test_process_len ... ok
test log::tests::test_output_when_not_coloring ... ok
test procfile::tests::test_set_concurrency ... ok
test procfile::tests::test_set_concurrency_all ... ok
test signal::tests::test_trap_signal_at_multithred ... ignored
test log::tests::test_output_when_coloring ... ok
test log::tests::test_error ... ok
test procfile::tests::test_set_concurrency_when_panic - should panic ... ok
test procfile::tests::test_parse_procfile ... ok
test env::tests::test_read_env ... ok
test stream_read::tests::test_new ... ok
test output::tests::test_handle_output ... ok
test process::tests::test_build_check_for_child_termination_thread - should panic ... ok

test result: ok. 14 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 3.05s

(⎈ |minikube:default)#2022-03-26 14:31|yukihirop@FukudanoMacBook-Pro-2:~/RustProjects/ultraman (issues36/fix_port)
```