### PR TITLE
Fix/panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v0.3.2
+
+- fix #55
+
 ## v0.3.1
 
 - [Breaking] fix `port_for` logic.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,7 +675,7 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "ultraman"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ultraman"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["yukihirop <te108186@gmail.com>"]
 repository = "https://github.com/yukihirop/ultraman"
 edition = "2018"

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -1,0 +1,16 @@
+# Development
+
+## Example
+
+```bash
+cd example/start
+cargo run start -p ./Procfile
+```
+
+## Release
+
+```bash
+cargo build
+cargo bump
+cargo publish --dry-run
+```

--- a/example/start/Procfile
+++ b/example/start/Procfile
@@ -2,3 +2,5 @@ exit_0: ./fixtures/exit_0.sh
 exit_1: ./fixtures/exit_1.sh
 loop: ./fixtures/loop.sh $MESSAGE
 web: bundle exec puma -p $PORT -C ./config/puma.rb
+early_out: seq 100
+sleep: sleep 20

--- a/src/process.rs
+++ b/src/process.rs
@@ -36,7 +36,10 @@ impl Process {
             String::from("PORT"),
             port_for(&env_path, port, concurrency_index).to_string(),
         );
-        read_env.insert(String::from("PS"), ps_for(process_name, concurrency_index + 1));
+        read_env.insert(
+            String::from("PS"),
+            ps_for(process_name, concurrency_index + 1),
+        );
         let shell = os_env::var("SHELL").expect("$SHELL is not set");
 
         Process {

--- a/src/stream_read.rs
+++ b/src/stream_read.rs
@@ -37,11 +37,17 @@ impl PipeStreamReader {
                             }
                             Ok(_) => {
                                 if byte[0] == 0x0A {
-                                    tx.send(match String::from_utf8(buf.clone()) {
+                                    match tx.send(match String::from_utf8(buf.clone()) {
                                         Ok(line) => Ok(PipedLine::Line(line)),
                                         Err(err) => Err(PipeError::NotUtf8(err)),
-                                    })
-                                    .unwrap();
+                                    }) {
+                                        Ok(_) => {}
+                                        Err(e) => {
+                                            println!("Failed to send message: {}", e);
+                                            break;
+                                        }
+                                    }
+
                                     buf.clear()
                                 } else {
                                     buf.push(byte[0])


### PR DESCRIPTION
### Summary

Resolve #55 

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Thanks for contributing to ultraman!


### Work

```Procfile
#Procfile
exit_0: ./fixtures/exit_0.sh
exit_1: ./fixtures/exit_1.sh
loop: ./fixtures/loop.sh $MESSAGE
web: bundle exec puma -p $PORT -C ./config/puma.rb
early_out: seq 100
sleep: sleep 20
```

#### before

```
     Running `target/debug/ultraman start --procfile ./example/start/Procfile`
20:18:40 system       | sleep.1      start at pid: 68085
20:18:40 system       | exit_1.1     start at pid: 68082
20:18:40 system       | exit_0.1     start at pid: 68086
20:18:40 system       | web.1        start at pid: 68084
20:18:40 system       | early_out.1  start at pid: 68081
20:18:40 system       | loop.1       start at pid: 68083
20:18:40 exit_1.1     | zsh:1: no such file or directory: ./fixtures/exit_1.sh
20:18:40 loop.1       | zsh:1: no such file or directory: ./fixtures/loop.sh
20:18:40 exit_0.1     | zsh:1: no such file or directory: ./fixtures/exit_0.sh
20:18:40 early_out.1  | 1
20:18:40 early_out.1  | 2
20:18:40 early_out.1  | 3
20:18:40 early_out.1  | 4
20:18:40 early_out.1  | 5
20:18:40 early_out.1  | 6
20:18:40 early_out.1  | 7
thread '<unnamed>' panicked at src/stream_read.rs:44:38:
called `Result::unwrap()` on an `Err` value: "SendError(..)"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
20:18:40 early_out.1  | exited with code 0
20:18:40 system       | sending SIGTERM for sleep.1      at pid 68085
20:18:40 system       | sending SIGTERM for exit_1.1     at pid 68082
20:18:40 system       | sending SIGTERM for exit_0.1     at pid 68086
20:18:40 system       | sending SIGTERM for web.1        at pid 68084
20:18:40 system       | sending SIGTERM for loop.1       at pid 68083
20:18:40 sleep.1      | terminated by SIGTERM
20:18:40 web.1        | terminated by SIGTERM
20:18:40 exit_0.1     | exited with code 127
20:18:40 system       | sending SIGTERM for exit_1.1     at pid 68082
20:18:40 system       | sending SIGTERM for loop.1       at pid 68083
20:18:40 loop.1       | exited with code 127
20:18:40 system       | sending SIGTERM for exit_1.1     at pid 68082
20:18:40 exit_1.1     | exited with code 127
```

#### after

```
     Running `/Users/y.fukuda/RustProjects/ultraman/target/debug/ultraman start --procfile ./Procfile`
20:24:37 system       | exit_1.1     start at pid: 72899
20:24:37 system       | web.1        start at pid: 72902
20:24:37 system       | early_out.1  start at pid: 72901
20:24:37 system       | sleep.1      start at pid: 72904
20:24:37 system       | loop.1       start at pid: 72900
20:24:37 system       | exit_0.1     start at pid: 72903
20:24:37 early_out.1  | 1
20:24:37 early_out.1  | 2
20:24:37 early_out.1  | 3
20:24:37 early_out.1  | 4
20:24:37 early_out.1  | 5
20:24:37 early_out.1  | 6
20:24:37 early_out.1  | 7
20:24:37 early_out.1  | 8
Failed to send message: sending on a disconnected channel
20:24:37 early_out.1  | exited with code 0
20:24:37 system       | sending SIGTERM for exit_1.1     at pid 72899
20:24:37 system       | sending SIGTERM for web.1        at pid 72902
20:24:37 system       | sending SIGTERM for sleep.1      at pid 72904
20:24:37 system       | sending SIGTERM for loop.1       at pid 72900
20:24:37 system       | sending SIGTERM for exit_0.1     at pid 72903
20:24:37 web.1        | terminated by SIGTERM
20:24:37 sleep.1      | terminated by SIGTERM
20:24:37 loop.1       | terminated by SIGTERM
20:24:37 exit_0.1     | terminated by SIGTERM
20:24:37 exit_1.1     | terminated by SIGTERM
```

### Test

- [x] cargo test
- [x] cargo build
- [x] cargo publish --dry-run