### PR TITLE
fix: Handle race condition in stream processing to prevent SendError …

### DIFF
--- a/src/stream_read.rs
+++ b/src/stream_read.rs
@@ -42,8 +42,7 @@ impl PipeStreamReader {
                                         Err(err) => Err(PipeError::NotUtf8(err)),
                                     }) {
                                         Ok(_) => {}
-                                        Err(e) => {
-                                            println!("Failed to send message: {}", e);
+                                        Err(_) => {
                                             break;
                                         }
                                     }
@@ -54,7 +53,9 @@ impl PipeStreamReader {
                                 }
                             }
                             Err(error) => {
-                                tx.send(Err(PipeError::IO(error))).unwrap();
+                                if let Err(_) = tx.send(Err(PipeError::IO(error))) {
+                                    break;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
…panic

Fixed a race condition that occurred when processes exited early while stream processing was still ongoing. The issue manifested as a panic with 'SendError(..)' when trying to send data through a disconnected channel.

Changes:
- Replace unwrap() with proper error handling in stream_read.rs:43 and :57
- Break out of processing loop when channel send fails instead of panicking
- Ensures graceful cleanup when processes terminate unexpectedly

Fixes #55

🤖 Generated with [Claude Code](https://claude.ai/code)

### Summary

Resolve #Issue

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Thanks for contributing to ultraman!


### Work


### Test
