### PR TITLE
feat: ✨ add shell completion command

### DIFF
--- a/src/cmd/completion.rs
+++ b/src/cmd/completion.rs
@@ -1,0 +1,22 @@
+use crate::opt::Opt;
+use std::io;
+use structopt::clap::Shell;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+#[structopt(about = "Generate shell completion scripts")]
+pub struct CompletionOpts {
+    #[structopt(
+        help = "Shell to generate completions for",
+        possible_values = &["bash", "zsh", "fish", "powershell", "elvish"]
+    )]
+    pub shell: Shell,
+}
+
+pub fn run(opts: CompletionOpts) -> Result<(), Box<dyn std::error::Error>> {
+    use structopt::clap;
+    let mut app = Opt::clap();
+    let app_name = app.get_name().to_string();
+    app.gen_completions_to(app_name, opts.shell, &mut io::stdout());
+    Ok(())
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,4 +1,5 @@
 pub mod check;
+pub mod completion;
 pub mod export;
 pub mod run;
 pub mod start;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if let Some(subcommand) = opt.subcommands {
         match subcommand {
             Ultraman::Check(opts) => cmd::check::run(opts),
+            Ultraman::Completion(opts) => cmd::completion::run(opts).expect("failed ultraman completion"),
             Ultraman::Start(opts) => cmd::start::run(opts).expect("failed ultraman start"),
             Ultraman::Run(opts) => cmd::run::run(opts),
             Ultraman::Export(opts) => cmd::export::run(opts).expect("failed ultraman export"),

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -1,4 +1,5 @@
 use crate::cmd::check::CheckOpts;
+use crate::cmd::completion::CompletionOpts;
 use crate::cmd::export::ExportOpts;
 use crate::cmd::run::RunOpts;
 use crate::cmd::start::StartOpts;
@@ -20,6 +21,9 @@ pub struct Opt {
 pub enum Ultraman {
     #[structopt(name = "check", about = "Validate your application's Procfile")]
     Check(CheckOpts),
+
+    #[structopt(name = "completion", about = "Generate shell completion scripts")]
+    Completion(CompletionOpts),
 
     #[structopt(name = "start", about = "Start the application")]
     Start(StartOpts),


### PR DESCRIPTION
Add ultraman completion command that generates shell completion scripts for bash, zsh, fish, powershell, and elvish shells.

- Create completion.rs module with shell completion logic
- Add completion command to CLI structure and main match statement
- Use structopt/clap built-in completion generation
- Support all major shell types with proper validation

Usage: ultraman completion <shell>

🤖 Generated with [Claude Code](https://claude.ai/code)